### PR TITLE
engine: fix invalid shrink transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ Cargo.lock
 *.log
 crash-*
 *.a
+*.o
 corpus
 crashes

--- a/bolero-engine/src/shrink.rs
+++ b/bolero-engine/src/shrink.rs
@@ -12,7 +12,7 @@ pub fn shrink<T: Test>(
     Shrinker::new(test, input, seed, driver_mode).shrink()
 }
 
-macro_rules! ensure {
+macro_rules! predicate {
     ($expr:expr) => {
         if !($expr) {
             return Err(());
@@ -21,30 +21,10 @@ macro_rules! ensure {
 }
 
 macro_rules! shrink_integer {
-    ($current:ident, $check:expr) => {{
+    ($current:expr, $check:expr) => {{
         let mut check = $check;
 
-        let mut lowest_panic = None;
-        let mut prev_value = $current;
-
-        while prev_value > 0 {
-            let next_value = prev_value / 2;
-            if check(next_value) {
-                lowest_panic = Some(next_value);
-                prev_value = next_value;
-            } else {
-                break;
-            }
-        }
-
-        while let Some(next_value) = prev_value.checked_sub(1) {
-            if check(next_value) {
-                lowest_panic = Some(next_value);
-            }
-            prev_value = next_value;
-        }
-
-        lowest_panic
+        (0..($current)).into_iter().find(|value| check(*value))
     }};
 }
 
@@ -52,9 +32,12 @@ macro_rules! shrink_integer {
 struct Shrinker<'a, T> {
     test: &'a mut T,
     input: Vec<u8>,
-    len: usize,
+    temp_input: Vec<u8>,
+    end: usize,
     seed: Option<u64>,
     driver_mode: Option<DriverMode>,
+    #[cfg(test)]
+    snapshot_input: Vec<u8>,
 }
 
 impl<'a, T: Test> Shrinker<'a, T> {
@@ -66,11 +49,14 @@ impl<'a, T: Test> Shrinker<'a, T> {
     ) -> Self {
         let len = input.len();
         Self {
+            temp_input: input.clone(),
             input,
-            len,
+            end: len,
             test,
             seed,
             driver_mode,
+            #[cfg(test)]
+            snapshot_input: vec![],
         }
     }
 
@@ -80,26 +66,35 @@ impl<'a, T: Test> Shrinker<'a, T> {
         let capture_backtrace = panic::capture_backtrace(false);
 
         if cfg!(test) {
+            panic::forward_panic(forward_panic);
             assert!(
                 self.execute().is_err(),
                 "shrinking should only be performed on a failing test"
             );
+            panic::forward_panic(false);
         }
 
         let mut was_changed;
         let start_time = Instant::now();
         loop {
-            was_changed = self.apply_truncation().is_ok();
+            was_changed = self.apply_truncation();
 
-            for index in 0..self.len {
-                if index >= self.len {
+            // empty input means we're done
+            if self.end == 0 {
+                break;
+            }
+
+            for index in 0..self.end {
+                if index >= self.end {
                     // the length changed so start a new loop
                     break;
                 }
 
-                was_changed |= self.apply_transforms(index);
+                self.apply_transforms(index, &mut was_changed);
             }
 
+            // we made it through all of the transforms without shrinking
+            // which means it's as small as it's going to get
             if !was_changed {
                 break;
             }
@@ -111,11 +106,12 @@ impl<'a, T: Test> Shrinker<'a, T> {
         }
 
         panic::capture_backtrace(capture_backtrace);
-        let error = self.execute().err().unwrap();
+        let error = self.execute().err()?;
         panic::capture_backtrace(false);
 
         let input = self.generate_value();
 
+        // restore settings
         panic::forward_panic(forward_panic);
         panic::capture_backtrace(capture_backtrace);
 
@@ -126,15 +122,41 @@ impl<'a, T: Test> Shrinker<'a, T> {
         })
     }
 
-    fn apply_transforms(&mut self, index: usize) -> bool {
-        let mut is_valid_transform = false;
-        is_valid_transform |= self.apply_lower_byte(index).is_ok();
-        is_valid_transform |= self.apply_sort(index).is_ok();
-        is_valid_transform |= self.apply_remove_chunk(index).is_ok();
-        is_valid_transform
+    fn apply_truncation(&mut self) -> bool {
+        self.apply("truncation end", |this| this.apply_truncation_end())
     }
 
-    fn apply_lower_byte(&mut self, index: usize) -> Result<(), ()> {
+    fn apply_truncation_end(&mut self) -> Result<(), ()> {
+        let prev_value = self.end;
+        let result = shrink_integer!(prev_value, |end| {
+            self.end = end;
+            self.execute().is_err()
+        });
+
+        if let Some(end) = result {
+            self.end = end;
+            Ok(())
+        } else {
+            // revert
+            self.end = prev_value;
+            Err(())
+        }
+    }
+
+    fn apply_transforms(&mut self, index: usize, was_changed: &mut bool) {
+        *was_changed |= self.apply("remove chunk", |this| this.apply_remove_chunk(index));
+
+        // try the more aggressive transforms before moving to the single-byte transforms
+        if *was_changed {
+            return;
+        }
+
+        *was_changed |= self.apply("sort", |this| this.apply_sort(index));
+
+        *was_changed |= self.apply("byte shrink", |this| this.apply_byte_shrink(index));
+    }
+
+    fn apply_byte_shrink(&mut self, index: usize) -> Result<(), ()> {
         let prev_value = self.input[index];
         let result = shrink_integer!(prev_value, |value| {
             self.input[index] = value;
@@ -151,78 +173,114 @@ impl<'a, T: Test> Shrinker<'a, T> {
         }
     }
 
-    fn apply_truncation(&mut self) -> Result<(), ()> {
-        let prev_value = self.input.len();
-        let result = shrink_integer!(prev_value, |value| {
-            self.len = value;
+    fn apply_remove_chunk(&mut self, index: usize) -> Result<(), ()> {
+        // since most generators are going to use at least the first byte we don't remove it
+        predicate!(index != 0);
+
+        let slice = &self.input[index..self.end];
+
+        // we need at least one byte to remove and one to shift up in its place
+        predicate!(slice.len() >= 2);
+
+        // store the previous input
+        let mut temp_input = core::mem::replace(&mut self.temp_input, vec![]);
+        temp_input.clear();
+        temp_input.extend_from_slice(slice);
+
+        // we need at least one byte to shift up
+        let max_len = temp_input.len() - 1;
+
+        let result = shrink_integer!(max_len, |diff| {
+            self.input.truncate(index);
+            let offset = max_len - diff;
+            let slice = &temp_input[offset..];
+
+            // ensure the slicing logic makes sense
+            if cfg!(test) {
+                // the slice should be at least 1 and equal to diff + 1
+                assert_eq!(slice.len(), diff + 1);
+            }
+
+            self.input.extend_from_slice(slice);
+            self.end = self.input.len();
             self.execute().is_err()
         });
 
-        if let Some(len) = result {
-            self.len = len;
-            self.input.truncate(len);
-            Ok(())
-        } else {
-            // revert
-            self.len = prev_value;
-            Err(())
-        }
-    }
-
-    fn apply_remove_chunk(&mut self, index: usize) -> Result<(), ()> {
-        let prev = self.input[index..].to_vec();
-        let mut lowest_panic = None;
-
-        for (offset, _) in prev.iter().enumerate() {
-            self.input.remove(index);
-            self.len -= 1;
-            if self.execute().is_err() {
-                lowest_panic = Some(offset);
-            }
-        }
-
         self.input.truncate(index);
-        let res = if let Some(offset) = lowest_panic {
-            self.input.extend_from_slice(&prev[offset..]);
+
+        let res = if let Some(diff) = result {
+            let offset = max_len - diff;
+            self.input.extend_from_slice(&temp_input[offset..]);
             Ok(())
         } else {
-            self.input.extend_from_slice(&prev[..]);
+            self.input.extend_from_slice(&temp_input);
             Err(())
         };
-        self.len = self.input.len();
+
+        self.temp_input = temp_input;
+        self.end = self.input.len();
 
         res
     }
 
     fn apply_sort(&mut self, index: usize) -> Result<(), ()> {
-        ensure!(index + 1 < self.input.len());
-        ensure!(self.input[index] > self.input[index + 1]);
+        // make sure we have at least 1 byte to swap with
+        predicate!(index + 1 < self.end);
+        predicate!(self.input[index] > self.input[index + 1]);
 
-        let first = self.input[index];
-        let second = self.input[index + 1];
-        self.input[index] = second;
-        self.input[index + 1] = first;
+        self.input.swap(index, index + 1);
 
         if self.execute().is_err() {
             return Ok(());
         }
 
         // revert
-        self.input[index] = first;
-        self.input[index + 1] = second;
+        self.input.swap(index, index + 1);
+
         Err(())
+    }
+
+    #[inline(always)]
+    fn apply<F: FnOnce(&mut Self) -> Result<(), ()>>(&mut self, transform: &str, f: F) -> bool {
+        // store a snapshot of the previous input
+        #[cfg(test)]
+        {
+            self.snapshot_input.truncate(0);
+            self.snapshot_input
+                .extend_from_slice(&self.input[..self.end]);
+        }
+
+        let result = f(self).is_ok();
+
+        // ensures that the test is failing under the current input
+        //
+        // if not, this would indicate a invalid transform or non-determinsitic test
+        #[cfg(test)]
+        if self.execute().is_ok() {
+            eprintln!(
+                "transform created non-failing test: {}\nBEFORE: {:?}\nAFTER: {:?}",
+                transform,
+                &self.snapshot_input,
+                &self.input[..self.end],
+            );
+            panic!();
+        }
+
+        let _ = transform;
+
+        result
     }
 
     fn execute(&mut self) -> Result<bool, PanicError> {
         self.test.test(&mut ShrinkInput {
-            input: &self.input[..self.len],
+            input: &self.input[..self.end],
             driver_mode: self.driver_mode,
         })
     }
 
     fn generate_value(&mut self) -> T::Value {
         self.test.generate_value(&mut ShrinkInput {
-            input: &self.input[..self.len],
+            input: &self.input[..self.end],
             driver_mode: self.driver_mode,
         })
     }
@@ -246,36 +304,40 @@ impl<'a, Output> TestInput<Output> for ShrinkInput<'a> {
 }
 
 macro_rules! shrink_test {
-    ($name:ident, $gen:expr, $expected:expr, $check:expr) => {
+    ($name:ident, $gen:expr, $input:expr, $expected:expr, $check:expr) => {
         #[test]
         fn $name() {
             #[allow(unused_imports)]
             use bolero_generator::{driver::DriverMode, gen, ValueGenerator};
 
+            panic::forward_panic(true);
+            panic::capture_backtrace(true);
+
             let mut test = crate::ClonedGeneratorTest::new($check, $gen);
-            let input = [255; 1024].to_vec();
+            let input = ($input).to_vec();
 
             let failure = Shrinker::new(&mut test, input, None, Some(DriverMode::Forced))
                 .shrink()
-                .unwrap();
+                .expect("should produce a result");
 
             assert_eq!(failure.input, $expected);
         }
     };
 }
 
-shrink_test!(u16_shrink_test, gen::<u16>(), 1, |value| {
+shrink_test!(u16_shrink_test, gen::<u16>(), [255u8; 2], 1, |value| {
     assert!(value < 20);
     assert!(value % 7 == 0);
 });
 
-shrink_test!(u32_shrink_test, gen::<u32>(), 20, |value| {
+shrink_test!(u32_shrink_test, gen::<u32>(), [255u8; 4], 20, |value| {
     assert!(value < 20);
 });
 
 shrink_test!(
     vec_shrink_test,
     gen::<Vec<u32>>().filter(|vec| vec.len() >= 3),
+    [255u8; 256],
     vec![4, 0, 0],
     |value: Vec<u32>| {
         assert!(value[0] < 4);
@@ -287,9 +349,22 @@ shrink_test!(
 shrink_test!(
     non_start_vec_shrink_test,
     gen::<Vec<u32>>().filter(|vec| vec.len() >= 3),
+    [255u8; 256],
     vec![0, 5, 0],
     |value: Vec<u32>| {
         assert!(value[1] < 5);
         assert!(value[2] < 6);
+    }
+);
+
+shrink_test!(
+    middle_vec_shrink_test,
+    gen::<Vec<u8>>().filter(|vec| vec.len() >= 3),
+    [255u8; 256],
+    vec![1, 1, 1],
+    |value: Vec<u8>| {
+        if value[0] > 0 && *value.last().unwrap() > 0 {
+            assert_eq!(value[1], 0);
+        }
     }
 );


### PR DESCRIPTION
In investigating #18 I found an issue with the `apply_remove_chunk` shrinker that would leave the input in a state that would not panic and end up with an empty message. I've added some checks to the shrinkers to make sure this doesn't happen, or if it does, it'll at least show what happened.