### PR TITLE
deprecate fuzz! in favor of check!

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://docs.rs/bolero/badge.svg)](https://docs.rs/bolero)
 [![License](https://img.shields.io/crates/l/bolero.svg)](https://github.com/camshaft/bolero/blob/master/LICENSE)
 
-fuzz and property testing framework
+fuzz and property testing front-end for Rust
 
 ## Book
 

--- a/bolero/Cargo.toml
+++ b/bolero/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bolero"
 version = "0.5.2"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
-description = "fuzz and property testing framework"
+description = "fuzz and property testing front-end"
 homepage = "https://github.com/camshaft/bolero"
 repository = "https://github.com/camshaft/bolero"
 keywords = ["testing", "quickcheck", "property", "fuzz", "fuzzing"]

--- a/book/src/cli-installation.md
+++ b/book/src/cli-installation.md
@@ -1,6 +1,6 @@
 # CLI Installation
 
-`bolero` provides a CLI program to execute fuzz tests, [`cargo-bolero`](https://crates.io/crates/cargo-bolero). It can be installed globally with cargo:
+`bolero` provides a CLI program to execute tests, [`cargo-bolero`](https://crates.io/crates/cargo-bolero). It can be installed globally with cargo:
 
 ```bash
 $ cargo install cargo-bolero -f

--- a/book/src/features/input-shrinking.md
+++ b/book/src/features/input-shrinking.md
@@ -15,7 +15,7 @@ From [PropEr Testing](https://propertesting.com/book_shrinking.html):
 Let's suppose we're testing a `MySet` data structure:
 
 ```rust
-use bolero::{fuzz, generator::*};
+use bolero::{check, generator::*};
 use my_set::MySet;
 
 #[derive(Debug, TypeGenerator)]
@@ -26,7 +26,7 @@ enum Operation {
 }
 
 fn main() {
-    fuzz!()
+    check!()
         .with_type::<Vec<Operation>>()
         .for_each(|operations| {
             let mut set = MySet::new();

--- a/book/src/features/private-testing.md
+++ b/book/src/features/private-testing.md
@@ -5,7 +5,7 @@
 ```rust
 #[test]
 fn my_property_test() {
-    bolero::fuzz!()
+    bolero::check!()
         .with_type()
         .cloned()
         .for_each(|value: u64| {

--- a/book/src/features/structured-testing.md
+++ b/book/src/features/structured-testing.md
@@ -26,7 +26,7 @@ enum Operation {
 Note that we've added `TypeGenerator` to the list of derives. This enables `bolero` to generate random values for `Operation`. We can combine that with a `Vec<Operation>` and get a list of operations to perform on our `MySet` data structure.
 
 ```rust
-use bolero::{fuzz, generator::*};
+use bolero::{check, generator::*};
 use my_set::MySet;
 
 #[derive(Debug, TypeGenerator)]
@@ -37,7 +37,7 @@ enum Operation {
 }
 
 fn main() {
-    fuzz!()
+    check!()
         .with_type::<Vec<Operation>>()
         .for_each(|operations| {
             let mut set = MySet::new();
@@ -62,7 +62,7 @@ fn main() {
 This basic test will make sure we don't panic on any of the list of operations. We can take it to the next step by using a test oracle to make sure the behavior of `MySet` is actually correct. Here we'll use `HashSet` from the `std` library:
 
 ```rust
-use bolero::{fuzz, generator::*};
+use bolero::{check, generator::*};
 use my_set::MySet;
 use std::collections::HashSet;
 
@@ -74,7 +74,7 @@ enum Operation {
 }
 
 fn main() {
-    fuzz!()
+    check!()
         .with_type::<Vec<Operation>>()
         .for_each(|operations| {
             let mut set = MySet::new();

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Bolero is a fuzzing and property testing framework for Rust programs.
+Bolero is a fuzzing and property testing front-end framework for Rust.
 
 From [Wikipedia](https://en.wikipedia.org/wiki/Fuzzing), fuzzing is described as:
 

--- a/book/src/tutorials/fibonacci.md
+++ b/book/src/tutorials/fibonacci.md
@@ -28,12 +28,12 @@ $ cargo bolero new fibonacci_test --generator
 ```
 
 ```rust
-// tests/fibonacci_test/fuzz_target.rs
-use bolero::fuzz;
+// tests/fibonacci_test/test_target.rs
+use bolero::check;
 use my_fibonacci::fibonacci;
 
 fn main() {
-    fuzz!()
+    check!()
         .with_type()
         .cloned()
         .for_each(|number: u64| {
@@ -49,7 +49,7 @@ $ cargo bolero test fibonacci_test
     Finished test [unoptimized + debuginfo] target(s) in 0.10s
      Running target/fuzz/build_62a8ab526939db81/x86_64-apple-darwin/debug/deps/fibonacci_test-f9f8f1dcc806b6b6
 ...
-thread 'main' panicked at 'attempt to add with overflow', my_fibonacci/tests/fibonacci_test/fuzz_target.rs:8:9
+thread 'main' panicked at 'attempt to add with overflow', my_fibonacci/tests/fibonacci_test/test_target.rs:8:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ======================== Test Failure ========================

--- a/cargo-bolero/README.md
+++ b/cargo-bolero/README.md
@@ -23,7 +23,7 @@ $ sudo apt install binutils-dev libunwind-dev
 Run an engine for a target
 
 USAGE:
-    cargo-bolero fuzz [FLAGS] [OPTIONS] <test>
+    cargo bolero test [FLAGS] [OPTIONS] <test>
 
 FLAGS:
         --all-features           Activate all available features
@@ -57,7 +57,7 @@ ARGS:
 Reduce the corpus of a test target with an engine
 
 USAGE:
-    cargo-bolero reduce [FLAGS] [OPTIONS] <test>
+    cargo bolero reduce [FLAGS] [OPTIONS] <test>
 
 FLAGS:
         --all-features           Activate all available features

--- a/cargo-bolero/src/new.rs
+++ b/cargo-bolero/src/new.rs
@@ -46,7 +46,7 @@ impl New {
         let target_dir = manifest_dir.join("tests").join(&self.test);
 
         mkdir(&target_dir);
-        write(target_dir.join("fuzz_target.rs"), file);
+        write(target_dir.join("test_target.rs"), file);
 
         mkdir(target_dir.join("corpus"));
         write(target_dir.join("corpus").join(".gitkeep"), "");
@@ -64,7 +64,7 @@ impl New {
                     r#"
 [[test]]
 name = "{name}"
-path = "tests/{name}/fuzz_target.rs"
+path = "tests/{name}/test_target.rs"
 harness = false
 "#,
                     name = self.test

--- a/cargo-bolero/src/test.rs
+++ b/cargo-bolero/src/test.rs
@@ -37,7 +37,7 @@ pub struct Args {
     #[structopt(short = "l", long)]
     pub max_input_length: Option<usize>,
 
-    /// Maximum amount of time to run a fuzz target before
+    /// Maximum amount of time to run a test target before
     /// failing
     #[structopt(short, long, default_value = "10s")]
     pub timeout: Duration,

--- a/cargo-bolero/tests/fuzz_bytes/fuzz_target.rs
+++ b/cargo-bolero/tests/fuzz_bytes/fuzz_target.rs
@@ -1,7 +1,7 @@
-use bolero::fuzz;
+use bolero::check;
 
 fn main() {
-    fuzz!().for_each(|input: &[u8]| {
+    check!().for_each(|input: &[u8]| {
         // TODO implement checks
         let _ = input;
     });

--- a/cargo-bolero/tests/fuzz_generator/fuzz_target.rs
+++ b/cargo-bolero/tests/fuzz_generator/fuzz_target.rs
@@ -1,7 +1,7 @@
-use bolero::fuzz;
+use bolero::check;
 
 fn main() {
-    fuzz!().with_type().for_each(|value: &u64| {
+    check!().with_type().for_each(|value: &u64| {
         // TODO implement checks
         let _ = value;
     });

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -13,13 +13,13 @@ pub fn add(a: u8, b: u8, should_panic: bool) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bolero::{fuzz, generator::*};
+    use bolero::{check, generator::*};
 
     #[test]
     fn add_test() {
         let should_panic = std::env::var("SHOULD_PANIC").is_ok();
 
-        fuzz!()
+        check!()
             .with_generator((0..254).map_gen(|a: u8| (a, a + 1)))
             .cloned()
             .for_each(|(a, b)| {
@@ -31,7 +31,7 @@ mod tests {
     fn other_test() {
         let should_panic = std::env::var("SHOULD_PANIC").is_ok();
 
-        fuzz!()
+        check!()
             .with_generator((0..254).map_gen(|a: u8| (a, a + 1)))
             .cloned()
             .for_each(|(a, b)| {
@@ -54,7 +54,7 @@ mod tests {
             }
         }
 
-        fuzz!().with_type::<T>().for_each(|_| {
+        check!().with_type::<T>().for_each(|_| {
             // nothing to assert
         })
     }

--- a/examples/basic/tests/fuzz_bytes/fuzz_target.rs
+++ b/examples/basic/tests/fuzz_bytes/fuzz_target.rs
@@ -1,11 +1,11 @@
 use basic::add;
-use bolero::fuzz;
+use bolero::check;
 use std::env;
 
 fn main() {
     let should_panic = env::var("SHOULD_PANIC").is_ok();
 
-    fuzz!().for_each(|input| {
+    check!().for_each(|input| {
         if input.len() < 2 {
             return;
         }

--- a/examples/basic/tests/fuzz_generator/fuzz_target.rs
+++ b/examples/basic/tests/fuzz_generator/fuzz_target.rs
@@ -1,10 +1,10 @@
 use basic::add;
-use bolero::{fuzz, generator::*};
+use bolero::{check, generator::*};
 
 fn main() {
     let should_panic = std::env::var("SHOULD_PANIC").is_ok();
 
-    fuzz!()
+    check!()
         .with_generator((0..254).map_gen(|a: u8| (a, a + 1)))
         .cloned()
         .for_each(|(a, b)| {

--- a/examples/basic/tests/fuzz_operations/fuzz_target.rs
+++ b/examples/basic/tests/fuzz_operations/fuzz_target.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use bolero::{fuzz, generator::*};
+use bolero::{check, generator::*};
 use std::collections::LinkedList;
 
 #[derive(Debug, TypeGenerator)]
@@ -16,7 +16,7 @@ fn main() {
         32
     };
 
-    fuzz!()
+    check!()
         .with_generator(gen::<Vec<Operation>>().with().len(0usize..=len))
         .for_each(|operations| {
             let mut subject: ArrayVec<[_; 32]> = ArrayVec::new();

--- a/examples/basic/tests/other.rs
+++ b/examples/basic/tests/other.rs
@@ -1,11 +1,11 @@
 use basic::add;
-use bolero::{fuzz, generator::*};
+use bolero::{check, generator::*};
 
 #[test]
 fn other_integration_test() {
     let should_panic = std::env::var("OTHER_SHOULD_PANIC").is_ok();
 
-    fuzz!()
+    check!()
         .with_generator((0..254).map_gen(|a: u8| (a, a + 1)))
         .cloned()
         .for_each(|(a, b)| {
@@ -20,7 +20,7 @@ mod nested {
     fn other_nested_integration_test() {
         let should_panic = std::env::var("OTHER_SHOULD_PANIC").is_ok();
 
-        fuzz!()
+        check!()
             .with_generator((0..254).map_gen(|a: u8| (a, a + 1)))
             .cloned()
             .for_each(|(a, b)| {

--- a/examples/workspace/crate_a/src/lib.rs
+++ b/examples/workspace/crate_a/src/lib.rs
@@ -8,7 +8,7 @@ pub fn run(a: u8, b: u8) -> u8 {
 
 #[test]
 fn bolero_test() {
-    bolero::fuzz!().with_type().cloned().for_each(|(a, b)| {
+    bolero::check!().with_type().cloned().for_each(|(a, b)| {
         run(a, b);
     });
 }

--- a/examples/workspace/crate_a/tests/fuzz_a/fuzz_target.rs
+++ b/examples/workspace/crate_a/tests/fuzz_a/fuzz_target.rs
@@ -1,8 +1,8 @@
-use bolero::fuzz;
+use bolero::check;
 use crate_a::run;
 
 fn main() {
-    fuzz!().with_type().cloned().for_each(|(a, b)| {
+    check!().with_type().cloned().for_each(|(a, b)| {
         run(a, b);
     });
 }

--- a/examples/workspace/crate_b/src/lib.rs
+++ b/examples/workspace/crate_b/src/lib.rs
@@ -8,7 +8,7 @@ pub fn run(a: u8, b: u8) -> u8 {
 
 #[test]
 fn bolero_test() {
-    bolero::fuzz!().with_type().cloned().for_each(|(a, b)| {
+    bolero::check!().with_type().cloned().for_each(|(a, b)| {
         run(a, b);
     });
 }

--- a/examples/workspace/crate_b/tests/fuzz_b/fuzz_target.rs
+++ b/examples/workspace/crate_b/tests/fuzz_b/fuzz_target.rs
@@ -1,8 +1,8 @@
-use bolero::fuzz;
+use bolero::check;
 use crate_b::run;
 
 fn main() {
-    fuzz!().with_type().cloned().for_each(|(a, b)| {
+    check!().with_type().cloned().for_each(|(a, b)| {
         run(a, b);
     });
 }


### PR DESCRIPTION
With the end goal of `bolero` becoming a front-end for various types of execution engines outside of fuzzing (e.g. [crux](https://github.com/camshaft/bolero/issues/34), [seer](https://github.com/dwrensha/seer), [haybale](https://github.com/PLSysSec/haybale), etc) we're deprecating `fuzz!` in favor of the previously-removed `check!`. The API stays exactly the same.