### PR TITLE
default to --sanitizer address

### DIFF
--- a/book/src/features/rust-stable.md
+++ b/book/src/features/rust-stable.md
@@ -4,7 +4,7 @@
 
 ```bash
 # does not require nightly
-$ cargo bolero test my_test_target
+$ cargo bolero test my_test_target --sanitizer NONE
 ```
 
 ## Sanitizer support

--- a/cargo-bolero/src/project.rs
+++ b/cargo-bolero/src/project.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 pub struct Project {
     /// Build with the sanitizer enabled
-    #[structopt(short, long)]
+    #[structopt(short, long, default_value = "address")]
     sanitizer: Vec<String>,
 
     /// Build for the target triple
@@ -144,6 +144,7 @@ impl Project {
         } else {
             None
         })
+        // https://github.com/rust-lang/rust/issues/47071
         .chain(if self.release() {
             Some("-Ccodegen-units=1")
         } else {


### PR DESCRIPTION
A sanitizer is really needed in order to get good results so this should be the default. Users can always opt out with `--sanitizer NONE`