### PR TITLE
generator-derive: use proc-macro2 directly

### DIFF
--- a/bolero-generator-derive/Cargo.toml
+++ b/bolero-generator-derive/Cargo.toml
@@ -14,5 +14,6 @@ readme = "../bolero-generator/README.md"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
+proc-macro2 = "1.0"
 quote = "1.0"
+syn = "1.0"

--- a/bolero-generator-derive/src/generator_attr.rs
+++ b/bolero-generator-derive/src/generator_attr.rs
@@ -1,7 +1,8 @@
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
-    export::TokenStream2, parse::Error, parse_quote, spanned::Spanned, Attribute, Expr, Lit, Meta,
-    MetaList, NestedMeta, Type, WhereClause,
+    parse::Error, parse_quote, spanned::Spanned, Attribute, Expr, Lit, Meta, MetaList, NestedMeta,
+    Type, WhereClause,
 };
 
 pub struct GeneratorAttr {

--- a/bolero-generator-derive/src/lib.rs
+++ b/bolero-generator-derive/src/lib.rs
@@ -4,13 +4,11 @@ mod generator_attr;
 
 use generator_attr::GeneratorAttr;
 use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
-    export::{Span, TokenStream2},
-    parse_macro_input,
-    spanned::Spanned,
-    Attribute, Data, DataEnum, DataStruct, DataUnion, DeriveInput, Error, Fields, FieldsNamed,
-    FieldsUnnamed, Generics, Ident, WhereClause,
+    parse_macro_input, spanned::Spanned, Attribute, Data, DataEnum, DataStruct, DataUnion,
+    DeriveInput, Error, Fields, FieldsNamed, FieldsUnnamed, Generics, Ident, WhereClause,
 };
 
 /// Derive the an implementation of `TypeGenerator` for the given type.

--- a/bolero-generator/src/bool.rs
+++ b/bolero-generator/src/bool.rs
@@ -21,7 +21,7 @@ impl ValueGenerator for bool {
 
 impl BooleanGenerator {
     pub fn weight(mut self, weight: f32) -> Self {
-        assert!(0.0 <= weight && weight <= 1.0);
+        assert!((0.0..=1.0).contains(&weight));
         self.weight = weight;
         self
     }

--- a/bolero-generator/src/std/mod.rs
+++ b/bolero-generator/src/std/mod.rs
@@ -71,7 +71,7 @@ impl<T: TypeGenerator> TypeGenerator for Mutex<T> {
     }
 
     fn mutate<D: Driver>(&mut self, driver: &mut D) -> Option<()> {
-        if let Ok(mut value) = self.lock() {
+        if let Ok(value) = self.get_mut() {
             value.mutate(driver)?;
             return Some(());
         }


### PR DESCRIPTION
We were using a private module from syn rather than importing proc-macro2 directly.