### PR TITLE
make the driver interface less aware of input representation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,10 @@ jobs:
         # TODO add honggfuzz back
         test: [unit-tests, libfuzzer, afl, examples-tests]
         sanitizer: [NONE]
+        exclude:
+          # honggfuzz is broken on macOS
+          - os: macos-latest
+            test: hongffuzz
         include:
           - rust: nightly
             os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         exclude:
           # honggfuzz is broken on macOS
           - os: macos-latest
-            test: hongffuzz
+            test: honggfuzz
         include:
           - rust: nightly
             os: ubuntu-latest

--- a/bolero-afl/src/lib.rs
+++ b/bolero-afl/src/lib.rs
@@ -43,6 +43,11 @@ pub mod fuzzer {
             self.driver_mode = Some(mode);
         }
 
+        fn set_shrink_time(&mut self, shrink_time: core::time::Duration) {
+            // we don't shrink with afl currently
+            let _ = shrink_time;
+        }
+
         fn run(self, mut test: T) -> Self::Output {
             panic::set_hook();
 

--- a/bolero-engine/src/lib.rs
+++ b/bolero-engine/src/lib.rs
@@ -3,6 +3,7 @@ pub use bolero_generator::{
     driver::{Driver, DriverMode},
     TypeGenerator, ValueGenerator,
 };
+use core::time::Duration;
 
 pub mod panic;
 #[cfg(feature = "rng")]
@@ -30,6 +31,7 @@ pub trait Engine<T: Test>: Sized {
     type Output;
 
     fn set_driver_mode(&mut self, mode: DriverMode);
+    fn set_shrink_time(&mut self, shrink_time: Duration);
     fn run(self, test: T) -> Self::Output;
 }
 

--- a/bolero-generator/src/bool.rs
+++ b/bolero-generator/src/bool.rs
@@ -39,14 +39,13 @@ impl ValueGenerator for BooleanGenerator {
     type Output = bool;
 
     fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-        let value = driver.gen::<u32>()? as f32 / core::u32::MAX as f32;
-        Some(value < self.weight)
+        driver.gen_bool(Some(self.weight))
     }
 }
 
 impl TypeGenerator for bool {
     fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-        Some(driver.gen::<u8>()? > (core::u8::MAX / 2))
+        driver.gen_bool(None)
     }
 }
 

--- a/bolero-generator/src/char.rs
+++ b/bolero-generator/src/char.rs
@@ -1,50 +1,22 @@
 use crate::{
-    bounded::{is_within, BoundedGenerator, BoundedValue},
-    driver::DriverMode,
-    Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, ValueGenerator,
+    bounded::{BoundedGenerator, BoundedValue},
+    Driver, TypeGenerator, TypeGeneratorWithParams, ValueGenerator,
 };
-use core::ops::{Range, RangeBounds};
+use core::ops::{Bound, Range};
 
 impl TypeGenerator for char {
     fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-        if driver.mode() == DriverMode::Forced {
-            Some(
-                TypeGenerator::generate(driver)
-                    .and_then(coerce_char)
-                    .unwrap_or_default(),
-            )
-        } else {
-            core::char::from_u32(TypeGenerator::generate(driver)?)
-        }
+        driver.gen_char(Bound::Unbounded, Bound::Unbounded)
     }
 }
 
-impl<R: RangeBounds<Self>> BoundedValue<R> for char {
-    type BoundValue = char;
-
-    fn is_within(&self, range_bounds: &R) -> bool {
-        is_within(self, range_bounds)
-    }
-
-    fn bind_within(&mut self, range_bounds: &R) {
-        use core::ops::Bound::*;
-
-        let start = match range_bounds.start_bound() {
-            Included(value) => Included(*value as u32),
-            Excluded(value) => Excluded(*value as u32),
-            Unbounded => Unbounded,
-        };
-
-        let end = match range_bounds.end_bound() {
-            Included(value) => Included(*value as u32),
-            Excluded(value) => Excluded(*value as u32),
-            Unbounded => Unbounded,
-        };
-
-        let mut value = *self as u32;
-        value.bind_within(&(start, end));
-
-        *self = coerce_char(value).unwrap_or_default()
+impl BoundedValue for char {
+    fn gen_bounded<D: Driver>(
+        driver: &mut D,
+        min: Bound<&Self>,
+        max: Bound<&Self>,
+    ) -> Option<Self> {
+        driver.gen_char(min, max)
     }
 }
 
@@ -57,23 +29,10 @@ impl ValueGenerator for char {
 }
 
 impl TypeGeneratorWithParams for char {
-    type Output = BoundedGenerator<TypeValueGenerator<char>, Range<char>>;
+    type Output = BoundedGenerator<Self, Range<Self>>;
 
     fn gen_with() -> Self::Output {
-        BoundedGenerator::new(Default::default(), (0 as char)..core::char::MAX)
-    }
-}
-
-fn coerce_char(mut value: u32) -> Option<char> {
-    value &= core::char::MAX as u32;
-    loop {
-        if let Some(value) = core::char::from_u32(value) {
-            return Some(value);
-        } else if let Some(next_value) = value.checked_sub(1) {
-            value = next_value;
-        } else {
-            return None;
-        }
+        BoundedGenerator::new((0 as char)..core::char::MAX)
     }
 }
 

--- a/bolero-generator/src/driver/bytes.rs
+++ b/bolero-generator/src/driver/bytes.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct ByteSliceDriver<'a> {
+    mode: DriverMode,
+    input: &'a [u8],
+}
+
+impl<'a> ByteSliceDriver<'a> {
+    pub fn new(input: &'a [u8], mode: Option<DriverMode>) -> Self {
+        let mode = mode.unwrap_or(DriverMode::Direct);
+
+        Self { input, mode }
+    }
+
+    #[inline]
+    pub fn new_direct(input: &'a [u8]) -> Self {
+        Self::new(input, Some(DriverMode::Direct))
+    }
+
+    #[inline]
+    pub fn new_forced(input: &'a [u8]) -> Self {
+        Self::new(input, Some(DriverMode::Forced))
+    }
+}
+
+impl<'a> FillBytes for ByteSliceDriver<'a> {
+    #[inline]
+    fn mode(&self) -> DriverMode {
+        self.mode
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) -> Option<()> {
+        match self.mode {
+            DriverMode::Forced => {
+                let offset = self.input.len().min(bytes.len());
+                let (current, remaining) = self.input.split_at(offset);
+                let (bytes_to_fill, bytes_to_zero) = bytes.split_at_mut(offset);
+                bytes_to_fill.copy_from_slice(current);
+                for byte in bytes_to_zero.iter_mut() {
+                    *byte = 0;
+                }
+                self.input = remaining;
+                Some(())
+            }
+            DriverMode::Direct => {
+                if bytes.len() > self.input.len() {
+                    return None;
+                }
+                let (current, remaining) = self.input.split_at(bytes.len());
+                bytes.copy_from_slice(current);
+                self.input = remaining;
+                Some(())
+            }
+        }
+    }
+}
+
+impl<'a> Driver for ByteSliceDriver<'a> {
+    gen_from_bytes!();
+}

--- a/bolero-generator/src/driver/macros.rs
+++ b/bolero-generator/src/driver/macros.rs
@@ -1,0 +1,94 @@
+macro_rules! gen_int {
+    ($name:ident, $ty:ident) => {
+        #[inline]
+        fn $name(&mut self, min: Bound<&$ty>, max: Bound<&$ty>) -> Option<$ty> {
+            Uniform::sample(self, min, max)
+        }
+    };
+}
+
+macro_rules! gen_float {
+    ($name:ident, $ty:ident) => {
+        #[inline]
+        fn $name(&mut self, min: Bound<&$ty>, max: Bound<&$ty>) -> Option<$ty> {
+            use core::ops::RangeBounds;
+
+            if let (Bound::Unbounded, Bound::Unbounded) = (min, max) {
+                let mut bytes = [0u8; core::mem::size_of::<$ty>()];
+                self.fill_bytes(&mut bytes)?;
+                return Some(<$ty>::from_le_bytes(bytes));
+            }
+
+            // if we're in direct mode, just sample a value and check if it's within the provided range
+            if self.mode() == DriverMode::Direct {
+                return self
+                    .$name(Bound::Unbounded, Bound::Unbounded)
+                    .filter(|value| (min, max).contains(value));
+            }
+
+            // TODO make this all less biased
+
+            if let Some(value) = self
+                .$name(Bound::Unbounded, Bound::Unbounded)
+                .filter(|value| (min, max).contains(value))
+            {
+                return Some(value);
+            }
+
+            match min {
+                Bound::Included(&v) => Some(v),
+                Bound::Excluded(&v) => Some(v + $ty::EPSILON),
+                Bound::Unbounded => Some($ty::MIN),
+            }
+        }
+    };
+}
+
+macro_rules! gen_from_bytes {
+    () => {
+        gen_int!(gen_u8, u8);
+
+        gen_int!(gen_i8, i8);
+
+        gen_int!(gen_u16, u16);
+
+        gen_int!(gen_i16, i16);
+
+        gen_int!(gen_u32, u32);
+
+        gen_int!(gen_i32, i32);
+
+        gen_int!(gen_u64, u64);
+
+        gen_int!(gen_i64, i64);
+
+        gen_int!(gen_u128, u128);
+
+        gen_int!(gen_i128, i128);
+
+        gen_int!(gen_usize, usize);
+
+        gen_int!(gen_isize, isize);
+
+        gen_float!(gen_f32, f32);
+
+        gen_float!(gen_f64, f64);
+
+        #[inline]
+        fn gen_char(&mut self, min: Bound<&char>, max: Bound<&char>) -> Option<char> {
+            char::sample(self, min, max)
+        }
+
+        #[inline]
+        fn gen_bool(&mut self, probability: Option<f32>) -> Option<bool> {
+            if let Some(probability) = probability {
+                let value = self.gen_u32(Bound::Unbounded, Bound::Unbounded)? as f32
+                    / core::u32::MAX as f32;
+                Some(value < probability)
+            } else {
+                let value: u8 = self.gen_u8(Bound::Unbounded, Bound::Unbounded)?;
+                Some(value < (u8::MAX / 2))
+            }
+        }
+    };
+}

--- a/bolero-generator/src/driver/rng.rs
+++ b/bolero-generator/src/driver/rng.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct DirectRng<R: RngCore>(R);
+
+impl<R: RngCore> DirectRng<R> {
+    pub fn new(rng: R) -> Self {
+        Self(rng)
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) -> Option<()> {
+        RngCore::try_fill_bytes(&mut self.0, bytes).ok()
+    }
+}
+
+impl<R: RngCore> FillBytes for DirectRng<R> {
+    #[inline]
+    fn mode(&self) -> DriverMode {
+        DriverMode::Direct
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) -> Option<()> {
+        RngCore::try_fill_bytes(&mut self.0, bytes).ok()
+    }
+}
+
+impl<R: RngCore> Driver for DirectRng<R> {
+    gen_from_bytes!();
+}
+
+#[derive(Debug)]
+pub struct ForcedRng<R: RngCore>(R);
+
+impl<R: RngCore> ForcedRng<R> {
+    #[inline]
+    pub fn new(rng: R) -> Self {
+        Self(rng)
+    }
+}
+
+impl<R: RngCore> FillBytes for ForcedRng<R> {
+    #[inline]
+    fn mode(&self) -> DriverMode {
+        DriverMode::Forced
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) -> Option<()> {
+        if RngCore::try_fill_bytes(&mut self.0, bytes).is_err() {
+            // if the rng fails to fill the remaining bytes, then we just start returning 0s
+            for byte in bytes.iter_mut() {
+                *byte = 0;
+            }
+        }
+        Some(())
+    }
+}
+
+impl<R: RngCore> Driver for ForcedRng<R> {
+    gen_from_bytes!();
+}

--- a/bolero-generator/src/lib.rs
+++ b/bolero-generator/src/lib.rs
@@ -7,6 +7,8 @@ use core::marker::PhantomData;
 #[macro_use]
 mod testing;
 
+mod uniform;
+
 #[cfg(feature = "either")]
 pub use either;
 

--- a/bolero-generator/src/uniform.rs
+++ b/bolero-generator/src/uniform.rs
@@ -1,0 +1,149 @@
+use crate::{bounded::BoundExt, driver::DriverMode};
+use core::ops::{Bound, RangeBounds};
+
+pub trait Uniform: Sized {
+    fn sample<F: FillBytes>(fill: &mut F, min: Bound<&Self>, max: Bound<&Self>) -> Option<Self>;
+}
+
+pub trait FillBytes {
+    fn mode(&self) -> DriverMode;
+    fn fill_bytes(&mut self, bytes: &mut [u8]) -> Option<()>;
+}
+
+macro_rules! uniform_int {
+    ($ty:ident, $unsigned:ident $(, $smaller:ident)?) => {
+        impl Uniform  for $ty {
+            #[inline]
+            fn sample<F: FillBytes>(fill: &mut F, min: Bound<&$ty>, max: Bound<&$ty>) -> Option<$ty> {
+                match (min, max) {
+                    (Bound::Unbounded, Bound::Unbounded)
+                    | (Bound::Unbounded, Bound::Included(&$ty::MAX))
+                    | (Bound::Included(&$ty::MIN), Bound::Unbounded)
+                    | (Bound::Included(&$ty::MIN), Bound::Included(&$ty::MAX)) => {
+                        let mut bytes = [0u8; core::mem::size_of::<$ty>()];
+                        fill.fill_bytes(&mut bytes)?;
+                        return Some(<$ty>::from_le_bytes(bytes));
+                    }
+                    (Bound::Included(&x), Bound::Included(&y)) if x == y => {
+                        return Some(x);
+                    }
+                    (Bound::Included(&x), Bound::Excluded(&y)) if x + 1 == y  => {
+                        return Some(x);
+                    }
+                    _ => {}
+                }
+
+                // if we're in direct mode, just sample a value and check if it's within the provided range
+                if fill.mode() == DriverMode::Direct {
+                    return Self::sample(fill, Bound::Unbounded, Bound::Unbounded)
+                        .filter(|value| (min, max).contains(value));
+                }
+
+                let lower = match min {
+                    Bound::Included(&v) => v,
+                    Bound::Excluded(v) => v.saturating_add(1),
+                    Bound::Unbounded => $ty::MIN,
+                };
+
+                let upper = match max {
+                    Bound::Included(&v) => v,
+                    Bound::Excluded(v) => v.saturating_sub(1),
+                    Bound::Unbounded => $ty::MAX,
+                };
+
+                // swap the two if reversed
+                let (lower, upper) = if upper > lower {
+                    (lower, upper)
+                } else {
+                    (upper, lower)
+                };
+
+                let range = upper.wrapping_sub(lower) as $unsigned;
+
+                if range == 0 {
+                    return Some(lower);
+                }
+
+                $({
+                    use core::convert::TryInto;
+
+                    // if the range fits in a smaller data type use that instead
+                    if let Ok(range) = range.try_into() {
+                        let value: $smaller = Uniform::sample(fill, Bound::Unbounded, Bound::Included(&range))?;
+                        let value = value as $ty;
+                        let value = lower.wrapping_add(value);
+
+                        // make sure we actually generated a correct value in tests
+                        if cfg!(test) {
+                            assert!((min, max).contains(&value), "{:?} < {} < {:?}", min, value, max);
+                        }
+
+                        return Some(value);
+                    }
+                })?
+
+                let value: $unsigned = Uniform::sample(fill, Bound::Unbounded, Bound::Unbounded)?;
+
+                // TODO make this less biased
+                let value = value % range;
+                let value = value as $ty;
+                let value = lower.wrapping_add(value);
+
+                // make sure we actually generated a correct value in tests
+                if cfg!(test) {
+                    assert!((min, max).contains(&value), "{:?} < {} < {:?}", min, value, max);
+                }
+
+                Some(value)
+            }
+        }
+    };
+}
+
+uniform_int!(u8, u8);
+uniform_int!(i8, u8);
+uniform_int!(u16, u16, u8);
+uniform_int!(i16, u16, u8);
+uniform_int!(u32, u32, u16);
+uniform_int!(i32, u32, u16);
+uniform_int!(u64, u64, u32);
+uniform_int!(i64, u64, u32);
+uniform_int!(u128, u128, u64);
+uniform_int!(i128, u128, u64);
+uniform_int!(usize, usize, u64);
+uniform_int!(isize, usize, u64);
+
+impl Uniform for char {
+    #[inline]
+    fn sample<F: FillBytes>(fill: &mut F, min: Bound<&Self>, max: Bound<&Self>) -> Option<Self> {
+        if fill.mode() == DriverMode::Direct {
+            let value = u32::sample(fill, Bound::Unbounded, Bound::Unbounded)?;
+            return char::from_u32(value);
+        }
+
+        const START: u32 = 0xD800;
+        const LEN: u32 = 0xE000 - START;
+
+        fn map_to_u32(c: &char) -> u32 {
+            match *c as u32 {
+                c if c >= START => c - LEN,
+                c => c,
+            }
+        }
+
+        let lower = BoundExt::map(min, map_to_u32);
+        let upper = match max {
+            Bound::Excluded(v) => Bound::Excluded(map_to_u32(v)),
+            Bound::Included(v) => Bound::Included(map_to_u32(v)),
+            Bound::Unbounded => Bound::Included(char::MAX as u32),
+        };
+
+        let mut value = u32::sample(fill, BoundExt::as_ref(&lower), BoundExt::as_ref(&upper))?;
+
+        if value >= START {
+            value += LEN;
+        }
+
+        char::from_u32(value)
+    }
+}

--- a/bolero-generator/src/uniform.rs
+++ b/bolero-generator/src/uniform.rs
@@ -135,7 +135,7 @@ impl Uniform for char {
         let upper = match max {
             Bound::Excluded(v) => Bound::Excluded(map_to_u32(v)),
             Bound::Included(v) => Bound::Included(map_to_u32(v)),
-            Bound::Unbounded => Bound::Included(char::MAX as u32),
+            Bound::Unbounded => Bound::Included(map_to_u32(&char::MAX)),
         };
 
         let mut value = u32::sample(fill, BoundExt::as_ref(&lower), BoundExt::as_ref(&upper))?;

--- a/bolero-honggfuzz/src/lib.rs
+++ b/bolero-honggfuzz/src/lib.rs
@@ -8,6 +8,7 @@ pub mod fuzzer {
     use bolero_engine::{
         panic as bolero_panic, ByteSliceTestInput, DriverMode, Engine, Never, TargetLocation, Test,
     };
+    use core::time::Duration;
     use std::{mem::MaybeUninit, slice};
 
     extern "C" {
@@ -30,6 +31,11 @@ pub mod fuzzer {
 
         fn set_driver_mode(&mut self, mode: DriverMode) {
             self.driver_mode = Some(mode);
+        }
+
+        fn set_shrink_time(&mut self, shrink_time: Duration) {
+            // we don't shrink with honggfuzz currently
+            let _ = shrink_time;
         }
 
         fn run(self, mut test: T) -> Self::Output {


### PR DESCRIPTION
while wiring up RMC support, it was discovered that it would be better to remove the ability to generate bytes on arbitrary slices and leave primitive value generate up to the actual driver.