### PR TITLE
Added --engine rmc

### DIFF
--- a/cargo-bolero/Cargo.toml
+++ b/cargo-bolero/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = ["afl", "libfuzzer"]
+default = ["afl", "libfuzzer", "rmc"]
 afl = ["bolero-afl"]
 honggfuzz = ["bolero-honggfuzz"]
 rmc = []

--- a/cargo-bolero/Cargo.toml
+++ b/cargo-bolero/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 default = ["afl", "libfuzzer"]
 afl = ["bolero-afl"]
 honggfuzz = ["bolero-honggfuzz"]
-rmc = ["bolero-rmc"]
+rmc = []
 libfuzzer = []
 
 [dependencies]
@@ -22,7 +22,6 @@ anyhow = "1.0"
 bit-set = "0.5"
 bolero-afl = { version = "0.6", path = "../bolero-afl", default-features = false, features = ["bin"], optional = true }
 bolero-honggfuzz = { version = "0.6", path = "../bolero-honggfuzz", default-features = false, features = ["bin"], optional = true }
-bolero-rmc = { version = "0.6", path = "../bolero-rmc", default-features = false, features = ["bin"], optional = true }
 humantime = "2"
 rustc_version = "0.4"
 structopt = "0.3"

--- a/cargo-bolero/Cargo.toml
+++ b/cargo-bolero/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 default = ["afl", "libfuzzer"]
 afl = ["bolero-afl"]
 honggfuzz = ["bolero-honggfuzz"]
+rmc = ["bolero-rmc"]
 libfuzzer = []
 
 [dependencies]
@@ -21,6 +22,7 @@ anyhow = "1.0"
 bit-set = "0.5"
 bolero-afl = { version = "0.6", path = "../bolero-afl", default-features = false, features = ["bin"], optional = true }
 bolero-honggfuzz = { version = "0.6", path = "../bolero-honggfuzz", default-features = false, features = ["bin"], optional = true }
+bolero-rmc = { version = "0.6", path = "../bolero-rmc", default-features = false, features = ["bin"], optional = true }
 humantime = "2"
 rustc_version = "0.4"
 structopt = "0.3"

--- a/cargo-bolero/src/engine.rs
+++ b/cargo-bolero/src/engine.rs
@@ -11,6 +11,9 @@ pub enum Engine {
 
     #[cfg(feature = "honggfuzz")]
     Honggfuzz,
+
+    #[cfg(feature = "rmc")]
+    Rmc,
 }
 
 impl Engine {
@@ -23,6 +26,9 @@ impl Engine {
 
             #[cfg(feature = "honggfuzz")]
             Self::Honggfuzz => crate::honggfuzz::test(selection, args),
+
+            #[cfg(feature = "rmc")]
+            Self::Rmc => crate::rmc::test(selection, args),
         }
     }
 
@@ -35,6 +41,9 @@ impl Engine {
 
             #[cfg(feature = "honggfuzz")]
             Self::Honggfuzz => crate::honggfuzz::reduce(selection, args),
+
+            #[cfg(feature = "rmc")]
+            Self::Rmc => Ok(()),
         }
     }
 }
@@ -51,6 +60,9 @@ impl FromStr for Engine {
 
             #[cfg(feature = "honggfuzz")]
             "honggfuzz" => Ok(Self::Honggfuzz),
+
+            #[cfg(feature = "rmc")]
+            "rmc" => Ok(Self::Rmc),
 
             _ => Err(format!("invalid fuzzer {:?}", value)),
         }

--- a/cargo-bolero/src/main.rs
+++ b/cargo-bolero/src/main.rs
@@ -14,6 +14,8 @@ mod manifest;
 mod new;
 mod project;
 mod reduce;
+#[cfg(feature = "rmc")]
+mod rmc;
 mod selection;
 mod test;
 mod test_target;

--- a/cargo-bolero/src/rmc.rs
+++ b/cargo-bolero/src/rmc.rs
@@ -1,27 +1,19 @@
 use crate::{exec, test, Selection};
-use anyhow::{anyhow, Result};
-use bit_set::BitSet;
-use core::cmp::Ordering;
-use std::{
-    fs,
-    io::{BufRead, BufReader, Result as IOResult, Write},
-    path::{Path, PathBuf},
-    process::Command,
-};
+use anyhow::Result;
+use std::process::Command;
 
 pub(crate) fn test(selection: &Selection, test_args: &test::Args) -> Result<()> {
     let _ = selection;
     let _ = test_args;
-    let mut rmc_cmd = String::from("cargo rmc");
-    rmc_cmd.push_str(" --function ");
-    rmc_cmd.push_str(&selection.test());
-    rmc_cmd.push_str(" --cbmc-args --object-bits 16");
-    Command::new("sh")
-          .env("RUSTFLAGS", "--cfg=fuzzing_rmc --cfg=fuzzing")
-          .arg("-c")
-          .arg(rmc_cmd)
-          .spawn()
-          .expect("failed to execute process");
+    let mut cmd = Command::new("cargo");
+    cmd.arg("rmc")
+        .arg("--function")
+        .arg(selection.test())
+        .arg("--cbmc-args")
+        .arg("--object-bits")
+        .arg("16");
+
+    exec(cmd)?;
 
     Ok(())
 }

--- a/cargo-bolero/src/rmc.rs
+++ b/cargo-bolero/src/rmc.rs
@@ -1,0 +1,27 @@
+use crate::{exec, test, Selection};
+use anyhow::{anyhow, Result};
+use bit_set::BitSet;
+use core::cmp::Ordering;
+use std::{
+    fs,
+    io::{BufRead, BufReader, Result as IOResult, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub(crate) fn test(selection: &Selection, test_args: &test::Args) -> Result<()> {
+    let _ = selection;
+    let _ = test_args;
+    let mut rmc_cmd = String::from("cargo rmc");
+    rmc_cmd.push_str(" --function ");
+    rmc_cmd.push_str(&selection.test());
+    rmc_cmd.push_str(" --cbmc-args --object-bits 16");
+    Command::new("sh")
+          .env("RUSTFLAGS", "--cfg=fuzzing_rmc --cfg=fuzzing")
+          .arg("-c")
+          .arg(rmc_cmd)
+          .spawn()
+          .expect("failed to execute process");
+
+    Ok(())
+}

--- a/cargo-bolero/src/selection.rs
+++ b/cargo-bolero/src/selection.rs
@@ -34,6 +34,10 @@ impl Selection {
 
         TestTarget::from_stdout(&output.stdout)
     }
+
+    pub fn test(&self) -> &str {
+        &self.test
+    }
 }
 
 impl Deref for Selection {


### PR DESCRIPTION
Added `rmc` as an option for `cargo bolero test`'s `--engine` option. The engine executes `cargo rmc` with the provided test function under the hood.