### PR TITLE
Renamed RMC to Kani

### DIFF
--- a/bolero-generator/src/range.rs
+++ b/bolero-generator/src/range.rs
@@ -63,6 +63,7 @@ macro_rules! range_generator {
             fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
                 let start = self.start.generate(driver)?;
                 let end = self.end.generate(driver)?;
+                #[allow(clippy::redundant_closure)]
                 Some($new(start, end))
             }
         }
@@ -71,6 +72,7 @@ macro_rules! range_generator {
             fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
                 let start = driver.gen()?;
                 let end = driver.gen()?;
+                #[allow(clippy::redundant_closure)]
                 Some($new(start, end))
             }
         }

--- a/cargo-bolero/Cargo.toml
+++ b/cargo-bolero/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = ["afl", "libfuzzer", "rmc"]
+default = ["afl", "libfuzzer", "kani"]
 afl = ["bolero-afl"]
 honggfuzz = ["bolero-honggfuzz"]
-rmc = []
+kani = []
 libfuzzer = []
 
 [dependencies]

--- a/cargo-bolero/src/engine.rs
+++ b/cargo-bolero/src/engine.rs
@@ -12,8 +12,8 @@ pub enum Engine {
     #[cfg(feature = "honggfuzz")]
     Honggfuzz,
 
-    #[cfg(feature = "rmc")]
-    Rmc,
+    #[cfg(feature = "kani")]
+    Kani,
 }
 
 impl Engine {
@@ -27,8 +27,8 @@ impl Engine {
             #[cfg(feature = "honggfuzz")]
             Self::Honggfuzz => crate::honggfuzz::test(selection, args),
 
-            #[cfg(feature = "rmc")]
-            Self::Rmc => crate::rmc::test(selection, args),
+            #[cfg(feature = "kani")]
+            Self::Kani => crate::kani::test(selection, args),
         }
     }
 
@@ -42,8 +42,8 @@ impl Engine {
             #[cfg(feature = "honggfuzz")]
             Self::Honggfuzz => crate::honggfuzz::reduce(selection, args),
 
-            #[cfg(feature = "rmc")]
-            Self::Rmc => Ok(()),
+            #[cfg(feature = "kani")]
+            Self::Kani => Ok(()),
         }
     }
 }
@@ -61,8 +61,8 @@ impl FromStr for Engine {
             #[cfg(feature = "honggfuzz")]
             "honggfuzz" => Ok(Self::Honggfuzz),
 
-            #[cfg(feature = "rmc")]
-            "rmc" => Ok(Self::Rmc),
+            #[cfg(feature = "kani")]
+            "kani" => Ok(Self::Kani),
 
             _ => Err(format!("invalid fuzzer {:?}", value)),
         }

--- a/cargo-bolero/src/kani.rs
+++ b/cargo-bolero/src/kani.rs
@@ -6,7 +6,7 @@ pub(crate) fn test(selection: &Selection, test_args: &test::Args) -> Result<()> 
     let _ = selection;
     let _ = test_args;
     let mut cmd = Command::new("cargo");
-    cmd.arg("rmc")
+    cmd.arg("kani")
         .arg("--function")
         .arg(selection.test())
         .arg("--cbmc-args")

--- a/cargo-bolero/src/main.rs
+++ b/cargo-bolero/src/main.rs
@@ -8,14 +8,14 @@ mod afl;
 mod engine;
 #[cfg(feature = "honggfuzz")]
 mod honggfuzz;
+#[cfg(feature = "kani")]
+mod kani;
 mod libfuzzer;
 mod list;
 mod manifest;
 mod new;
 mod project;
 mod reduce;
-#[cfg(feature = "rmc")]
-mod rmc;
 mod selection;
 mod test;
 mod test_target;


### PR DESCRIPTION
RMC has been renamed to Kani. This PR updates any references to RMC to instead refer to Kani.