### PR TITLE
Update cargo kani args

### DIFF
--- a/cargo-bolero/src/kani.rs
+++ b/cargo-bolero/src/kani.rs
@@ -7,11 +7,8 @@ pub(crate) fn test(selection: &Selection, test_args: &test::Args) -> Result<()> 
     let _ = test_args;
     let mut cmd = Command::new("cargo");
     cmd.arg("kani")
-        .arg("--function")
-        .arg(selection.test())
-        .arg("--cbmc-args")
-        .arg("--object-bits")
-        .arg("16");
+        .arg("--harness")
+        .arg(selection.test());
 
     exec(cmd)?;
 

--- a/cargo-bolero/src/kani.rs
+++ b/cargo-bolero/src/kani.rs
@@ -7,6 +7,7 @@ pub(crate) fn test(selection: &Selection, test_args: &test::Args) -> Result<()> 
     let _ = test_args;
     let mut cmd = Command::new("cargo");
     cmd.arg("kani")
+        .arg("--tests")
         .arg("--harness")
         .arg(selection.test());
 


### PR DESCRIPTION
Update `cargo kani` args:
1. Replace deprecated `--function` option with `--harness`
2. Remove unneeded `--cbmc-args --object-bits 16` which is now the default for `cargo kani`
3. Add `--tests`