### PR TITLE
Have new create a main.rs target, simplifying the Cargo.toml

### DIFF
--- a/book/src/tutorials/fibonacci.md
+++ b/book/src/tutorials/fibonacci.md
@@ -28,7 +28,7 @@ $ cargo bolero new fibonacci_test --generator
 ```
 
 ```rust
-// tests/fibonacci_test/test_target.rs
+// tests/fibonacci_test/main.rs
 use bolero::check;
 use my_fibonacci::fibonacci;
 
@@ -49,7 +49,7 @@ $ cargo bolero test fibonacci_test
     Finished test [unoptimized + debuginfo] target(s) in 0.10s
      Running target/fuzz/build_62a8ab526939db81/x86_64-apple-darwin/debug/deps/fibonacci_test-f9f8f1dcc806b6b6
 ...
-thread 'main' panicked at 'attempt to add with overflow', my_fibonacci/tests/fibonacci_test/test_target.rs:8:9
+thread 'main' panicked at 'attempt to add with overflow', my_fibonacci/tests/fibonacci_test/main.rs:8:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ======================== Test Failure ========================

--- a/cargo-bolero/src/new.rs
+++ b/cargo-bolero/src/new.rs
@@ -46,7 +46,7 @@ impl New {
         let target_dir = manifest_dir.join("tests").join(&self.test);
 
         mkdir(&target_dir);
-        write(target_dir.join("test_target.rs"), file);
+        write(target_dir.join("main.rs"), file);
 
         mkdir(target_dir.join("corpus"));
         write(target_dir.join("corpus").join(".gitkeep"), "");
@@ -64,7 +64,6 @@ impl New {
                     r#"
 [[test]]
 name = "{name}"
-path = "tests/{name}/test_target.rs"
 harness = false
 "#,
                     name = self.test


### PR DESCRIPTION
Hey! So following https://github.com/near/wasmer/pull/138 we noticed that cargo-bolero would work well with a test target named `main.rs`, as other rust integration tests usually do.

Is there any reason to name the main file `test_target.rs` instead of `main.rs`, now that it is no longer called `fuzz_target`? (I could see that it went main.rs -> fuzz_target.rs -> test_target.rs in the source code)

If there is none, this PR should be enough to make the renaming back to main.rs by default, so that `cargo bolero new` defaults to the "rust standard" for integration tests again :)

Anyway, thank you for cargo-bolero, I've started actually using it and it's being really great! :)