### PR TITLE
Remove bolero from kani dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,4 +138,4 @@ jobs:
     - name: Test
       working-directory: examples/basic
       run: |
-        cargo bolero test tests::add_test --engine kani
+        cargo kani

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,4 +138,4 @@ jobs:
     - name: Test
       working-directory: examples/basic
       run: |
-        cargo kani
+        cargo bolero test tests::add_test --engine kani

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -10,10 +10,6 @@ arrayvec = "0.5"
 [dev-dependencies]
 bolero = { path = "../../bolero" }
 
-# TODO remove this once this is fixed: https://github.com/model-checking/kani/issues/473
-[target.'cfg(kani)'.dependencies]
-bolero = { path = "../../bolero" }
-
 [workspace]
 members = ["."]
 

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -10,12 +10,12 @@ pub fn add(a: u8, b: u8, should_panic: bool) -> u8 {
     }
 }
 
-#[cfg(any(test, kani))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use bolero::{check, generator::*};
 
-    #[cfg_attr(not(kani), test)]
+    #[test]
     #[cfg_attr(kani, kani::proof)]
     fn add_test() {
         let should_panic = if cfg!(kani) {


### PR DESCRIPTION
Remove hack of adding `bolero` as a dependency for Kani, which is no longer needed.

Also, run kani in CI via `cargo bolero test --engine kani`, which is the documented method of running Kani.