### PR TITLE
Improve anyhow error handling

### DIFF
--- a/cargo-bolero/src/engine.rs
+++ b/cargo-bolero/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::{reduce, selection::Selection, test};
-use anyhow::Error;
+use anyhow::Result;
 use std::str::FromStr;
 
 #[derive(Debug)]
@@ -17,7 +17,7 @@ pub enum Engine {
 }
 
 impl Engine {
-    pub fn test(&self, selection: &Selection, args: &test::Args) -> Result<(), Error> {
+    pub fn test(&self, selection: &Selection, args: &test::Args) -> Result<()> {
         match self {
             Self::Libfuzzer => crate::libfuzzer::test(selection, args),
 
@@ -32,7 +32,7 @@ impl Engine {
         }
     }
 
-    pub fn reduce(&self, selection: &Selection, args: &reduce::Args) -> Result<(), Error> {
+    pub fn reduce(&self, selection: &Selection, args: &reduce::Args) -> Result<()> {
         match self {
             Self::Libfuzzer => crate::libfuzzer::reduce(selection, args),
 

--- a/cargo-bolero/src/list.rs
+++ b/cargo-bolero/src/list.rs
@@ -12,12 +12,12 @@ pub struct List {
 
 impl List {
     pub fn exec(&self) -> Result<()> {
-        let mut build_command = self.cmd("test", &[], None);
+        let mut build_command = self.cmd("test", &[], None)?;
         build_command.arg("--no-run");
         exec(build_command)?;
 
         let output = self
-            .cmd("test", &[], None)
+            .cmd("test", &[], None)?
             .arg("--")
             .arg("--nocapture")
             .env("CARGO_BOLERO_SELECT", "all")

--- a/cargo-bolero/src/main.rs
+++ b/cargo-bolero/src/main.rs
@@ -51,7 +51,8 @@ fn main() {
         });
 
     if let Err(err) = Commands::from_iter(args).exec() {
-        eprintln!("error: {}", err);
+        // Formatting anyhow error with {:#} to print all the error causes.
+        eprintln!("error: {:#}", err);
         std::process::exit(1);
     }
 }

--- a/cargo-bolero/src/selection.rs
+++ b/cargo-bolero/src/selection.rs
@@ -14,7 +14,7 @@ pub struct Selection {
 
 impl Selection {
     pub fn test_target(&self, flags: &[&str], fuzzer: &str) -> Result<TestTarget> {
-        let mut build_command = self.cmd("test", flags, Some(fuzzer));
+        let mut build_command = self.cmd("test", flags, Some(fuzzer))?;
         build_command
             .arg(&self.test)
             .arg("--no-run")
@@ -23,7 +23,7 @@ impl Selection {
         exec(build_command)?;
 
         let output = self
-            .cmd("test", flags, Some(fuzzer))
+            .cmd("test", flags, Some(fuzzer))?
             .arg(&self.test)
             .arg("--")
             .arg("--nocapture")


### PR DESCRIPTION
Print all the causes with {:#} formatter and replace .unwrap() with ?.

When `cargo bolero test` is run, previously the error due to missing rustup was
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }'
```

Now the error is:
```
error: failed to determine nightly toolchain version: No such file or directory (os error 2)
```

This way it is easier for the user to determine that nightly toolchain is used and pass `--sanitizer NONE` to switch away from the nightly toolchain or install the missing toolchain.