### PR TITLE
Change bolero-generator example to depend on 0.8

### DIFF
--- a/bolero-generator/README.md
+++ b/bolero-generator/README.md
@@ -8,7 +8,7 @@ value generator for testing and fuzzing
 
 ```toml
 [dependencies]
-bolero-generator = "0.4"
+bolero-generator = "0.8"
 ```
 
 ## Usage


### PR DESCRIPTION
The README example for bolero-generator is the first example one sees when exploring the package on crates.io. Updating this to reflect 0.8 avoids newcomers accidentally using an older version.