### PR TITLE
do not require importing bolero_generator or TypeGenerator in order to derive

### DIFF
--- a/bolero-generator-derive/Cargo.toml
+++ b/bolero-generator-derive/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../bolero-generator/README.md"
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = "1.2"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"


### PR DESCRIPTION
Fixes #105

This works with both imports from bolero::generator and bolero_generator, while before people had to imperatively import from bolero_generator and explicitly use TypeGenerator.