### PR TITLE
Expose functions like `bolero::gen` and `bolero::gen_with`

### DIFF
--- a/bolero/src/lib.rs
+++ b/bolero/src/lib.rs
@@ -26,8 +26,12 @@ cfg_if::cfg_if! {
 
 /// Re-export of [`bolero_generator`]
 pub mod generator {
+    // TODO: remove the use of prelude::* for the next major release
     pub use bolero_generator::{self, prelude::*};
 }
+
+// For users' sake, re-expose the prelude functions straight under bolero::
+pub use bolero_generator::prelude::*;
 
 #[doc(hidden)]
 pub use bolero_engine::{self, TargetLocation, __item_path__};

--- a/bolero/src/lib.rs
+++ b/bolero/src/lib.rs
@@ -26,7 +26,6 @@ cfg_if::cfg_if! {
 
 /// Re-export of [`bolero_generator`]
 pub mod generator {
-    // TODO: remove the use of prelude::* for the next major release
     pub use bolero_generator::{self, prelude::*};
 }
 


### PR DESCRIPTION
Right now as a user, I need to write `bolero::generator::gen_with()`. While this works, it would be much mork convenient to just be able to write `bolero::gen()` out-of-the-box.

(I don't think `use` statements are a good solution to that: `gen()` would be too short, unclear on where the function is coming from, and having to `use bolero::generator::gen as bolero_gen;` manually at the top of each file without rust-analyzer's help would be pretty cumbersome)

WDYT?