### PR TITLE
display backtraces on panic from cargo test

### DIFF
--- a/bolero-libfuzzer/src/lib.rs
+++ b/bolero-libfuzzer/src/lib.rs
@@ -65,10 +65,10 @@ pub mod fuzzer {
                             test.shrink(slice.to_vec(), None, driver_mode, self.shrink_time);
 
                         if let Some(shrunken) = shrunken {
-                            eprintln!("{}", shrunken);
+                            eprintln!("{:#}", shrunken);
                         } else {
                             eprintln!(
-                                "{}",
+                                "{:#}",
                                 TestFailure {
                                     seed: None,
                                     error,

--- a/bolero/src/test/mod.rs
+++ b/bolero/src/test/mod.rs
@@ -137,10 +137,10 @@ where
                             test.shrink(buffer.clone(), data.seed(), driver_mode, shrink_time);
 
                         if let Some(shrunken) = shrunken {
-                            format!("{}", shrunken)
+                            format!("{:#}", shrunken)
                         } else {
                             format!(
-                                "{}",
+                                "{:#}",
                                 TestFailure {
                                     seed: data.seed(),
                                     error,
@@ -165,13 +165,13 @@ where
                         );
 
                         if let Some(shrunken) = shrunken {
-                            format!("{}", shrunken)
+                            format!("{:#}", shrunken)
                         } else {
                             buffer.clear();
                             let mut input = conf.input(&mut buffer);
                             let input = test.generate_value(&mut input);
                             format!(
-                                "{}",
+                                "{:#}",
                                 TestFailure {
                                     seed: data.seed(),
                                     error,


### PR DESCRIPTION
Without this, running `RUST_BACKTRACE=1 cargo test my_bolero_test` shows the backtrace from the internals of where cargo-bolero re-panics, but does not actually show the backtrace of where the test itself did panic