### PR TITLE
run crashes before corpus when running cargo test

### DIFF
--- a/bolero/src/test/mod.rs
+++ b/bolero/src/test/mod.rs
@@ -87,11 +87,11 @@ impl TestEngine {
 
     fn tests(&self) -> Vec<NamedTest> {
         empty()
-            .chain(self.file_tests(["corpus"].iter().cloned()))
             .chain(self.file_tests(["crashes"].iter().cloned()))
-            .chain(self.file_tests(["afl_state", "hangs"].iter().cloned()))
-            .chain(self.file_tests(["afl_state", "queue"].iter().cloned()))
             .chain(self.file_tests(["afl_state", "crashes"].iter().cloned()))
+            .chain(self.file_tests(["afl_state", "hangs"].iter().cloned()))
+            .chain(self.file_tests(["corpus"].iter().cloned()))
+            .chain(self.file_tests(["afl_state", "queue"].iter().cloned()))
             .chain(self.rng_tests())
             .collect()
     }


### PR DESCRIPTION
This makes cargo test likely to crash faster than the other way around, which in turn leads to faster iteration rate

This is a small improvement compared to #114, but always worth it even if #114 were to land