### PR TITLE
Expose the `.cloned()` function only when the generator output can actually be cloned

### DIFF
--- a/bolero/src/lib.rs
+++ b/bolero/src/lib.rs
@@ -367,7 +367,11 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<G, Engine> TestTarget<G, Engine, BorrowedInput> {
+impl<G, Engine> TestTarget<G, Engine, BorrowedInput>
+where
+    G: generator::ValueGenerator,
+    <G as generator::ValueGenerator>::Output: Clone,
+{
     /// Use a cloned value for the test input
     ///
     /// Cloning the test inputs will force a call to [`Clone::clone`]


### PR DESCRIPTION
Hopefully closes #24.

That said somehow I haven’t been able to repro the issue today, and last time I hit it I fixed it in my code without keeping the reproducer. That said, `.with_type()` already has bounds for `Debug` and `TypeGenerator`; so the only thing that could be missing should be `Clone` for `.cloned()`.

I think even if it does not fix #24 this makes sense to merge, as it already encodes the information in a friendlier-to-rustc way than before, and does not expose a `.cloned()` method that would create an impossible-to-use `TestTarget` :)