### PR TITLE
Fix `#[derive(TypeGenerator)]`

### DIFF
--- a/bolero-generator-derive/src/generator_attr.rs
+++ b/bolero-generator-derive/src/generator_attr.rs
@@ -1,9 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned, ToTokens};
-use syn::{
-    parse::Error, parse_quote, spanned::Spanned, Attribute, Expr, Lit, Meta, MetaList, NestedMeta,
-    Type, WhereClause,
-};
+use syn::{parse::Error, spanned::Spanned, Attribute, Expr, Lit, Meta, MetaList, NestedMeta};
 
 pub struct GeneratorAttr {
     krate: TokenStream2,
@@ -100,15 +97,6 @@ impl GeneratorAttr {
 
                 Err(error)
             }
-        }
-    }
-
-    pub fn apply_constraint(&self, ty: &Type, where_clause: &mut WhereClause) {
-        if self.generator.is_none() {
-            let span = ty.span();
-            let krate = &self.krate;
-            let constraint = quote_spanned!(span=> : #krate::TypeGenerator);
-            where_clause.predicates.push(parse_quote!(#ty #constraint));
         }
     }
 }

--- a/bolero-generator-derive/src/lib.rs
+++ b/bolero-generator-derive/src/lib.rs
@@ -83,8 +83,8 @@ fn generate_struct_type_gen(
     name: &Ident,
     data_struct: DataStruct,
 ) -> (TokenStream2, TokenStream2) {
-    let value = generate_fields_type_gen(krate, &name, &data_struct.fields);
-    let destructure = generate_fields_type_destructure(&name, &data_struct.fields);
+    let value = generate_fields_type_gen(krate, name, &data_struct.fields);
+    let destructure = generate_fields_type_destructure(name, &data_struct.fields);
     let mutate_body = generate_fields_type_mutate(krate, &data_struct.fields);
 
     let generate_method = quote!(

--- a/bolero-generator/tests/derive_test.rs
+++ b/bolero-generator/tests/derive_test.rs
@@ -41,6 +41,23 @@ pub enum Enum {
     Clear,
 }
 
+#[derive(Debug, Clone, TypeGenerator, PartialEq)]
+pub enum Expr {
+    Int(i32),
+    If {
+        test_expr: Box<Expr>,
+        then_expr: Box<Expr>,
+        else_expr: Box<Expr>,
+    },
+}
+
+#[derive(Debug, Clone, TypeGenerator, PartialEq)]
+pub enum GenericTypes<T1, T2> {
+    T1Value(T1),
+    T2Value(T2),
+    NoValue,
+}
+
 #[derive(TypeGenerator)]
 pub union Union {
     a: u32,


### PR DESCRIPTION
This PR fixes the macro for `#[derive(TypeGenerator)]` and resolves #121

 In particular, these are the changes made:
  1. Avoid adding trait bounds for non-generic types (this is what caused problems in #121).
  2. Refactor code into a more functional style. The top-level function adds trait bounds, retrieves the `generate` and `mutate` methods, and emits the generated  `impl TypeGenerator for ...` at the end.
  3. Add `enum` tests for the macro (with recursive variants, type parameters)
  4. Add comments for most important functions and steps in the generation.

Regarding (1), it wasn't clear to me why non-generic types were added in `where` clauses. Removing the `apply_constraint` function (which did this) doesn't cause a testing regression. Trait bounds are now added to each type parameter in `#impl_generics`.

Using the example in #121, this is what was produced before:

```rust
impl bolero_generator::TypeGenerator for Expr
where
    i32: bolero_generator::TypeGenerator,
    Box<Expr>: bolero_generator::TypeGenerator,
    Box<Expr>: bolero_generator::TypeGenerator,
    Box<Expr>: bolero_generator::TypeGenerator,
{ ...
```

Now we produce this instead:

```rust
#[automatically_derived]
impl bolero::generator::bolero_generator::TypeGenerator for Expr {
```

If the `enum` contains type parameters, as in the example added in this PR

```rust
pub enum GenericTypes<T1, T2> {
    T1Value(T1),
    T2Value(T2),
    NoValue,
}
```
then we add trait bounds to `T1` and `T2`

```rust
#[automatically_derived]
impl<
    T1: bolero::generator::bolero_generator::TypeGenerator,
    T2: bolero::generator::bolero_generator::TypeGenerator,
> bolero::generator::bolero_generator::TypeGenerator for GenericTypes<T1, T2> {
```
