### PR TITLE
Update `book` workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -7,23 +7,20 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    permissions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v3.4.0
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1.1.14
+        uses: peaceiris/actions-mdbook@v1.2.0
         with:
           mdbook-version: '0.3.5'
 
       - run: mdbook build book
 
       - name: Build and Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
-          ACCESS_TOKEN: ${{ secrets.BOOK_SECRET }}
-          BRANCH: gh-pages
-          FOLDER: target/book
+          folder: target/book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-20.04
-    permissions: write
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3.4.0


### PR DESCRIPTION
Deployments using the `book` workflow haven't worked for a while. This PR updates the book workflow so it's similar to [Kani's](https://github.com/model-checking/kani/blob/main/.github/workflows/kani.yml#L91). Let's see if that works.

Updates to the most recent versions for all dependencies so #94 and #125 could be closed with this one.