### PR TITLE
fix: add generator for arbitrary sized arrays

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,8 +153,16 @@ jobs:
         repository: ${{ matrix.repo }}
         path: "target/integration/${{ matrix.repo }}"
 
+    - uses: actions-rs/toolchain@v1.0.7
+      id: toolchain
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
     - name: Add patch
       working-directory: target/integration/${{ matrix.repo }}
+      # TODO move this into a script: https://github.com/camshaft/bolero/issues/132
       run: |
         cat <<EOF >> Cargo.toml
         [patch.crates-io]
@@ -163,13 +171,6 @@ jobs:
         bolero-generator = { path = "../../../../bolero-generator" }
         bolero-generator-derive = { path = "../../../../bolero-generator-derive" }
         EOF
-
-    - uses: actions-rs/toolchain@v1.0.7
-      id: toolchain
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
 
     - uses: camshaft/rust-cache@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,3 +137,48 @@ jobs:
       with:
         working-directory: examples/basic
         args: --tests
+
+  # run integration tests with our main consumers
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ["aws/s2n-quic"]
+
+    steps:
+    - uses: actions/checkout@v3.5.0
+
+    - uses: actions/checkout@v3.5.0
+      with:
+        repository: ${{ matrix.repo }}
+        path: "target/integration/${{ matrix.repo }}"
+
+    - name: Add patch
+      working-directory: target/integration/${{ matrix.repo }}
+      run: |
+        cat <<EOF >> Cargo.toml
+        [patch.crates-io]
+        bolero = { path = "../../../../bolero" }
+        bolero-engine = { path = "../../../../bolero-engine" }
+        bolero-generator = { path = "../../../../bolero-generator" }
+        bolero-generator-derive = { path = "../../../../bolero-generator-derive" }
+        EOF
+
+    - uses: actions-rs/toolchain@v1.0.7
+      id: toolchain
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
+    - uses: camshaft/rust-cache@v1
+      with:
+        key: ${{ matrix.repo }}
+
+    - name: Build
+      working-directory: target/integration/${{ matrix.repo }}
+      run: cargo build --tests
+
+    - name: Tests
+      working-directory: target/integration/${{ matrix.repo }}
+      run: cargo test

--- a/bolero-generator-derive/src/lib.rs
+++ b/bolero-generator-derive/src/lib.rs
@@ -21,13 +21,14 @@ fn crate_ident(from: FoundCrate) -> Ident {
 }
 
 fn crate_path() -> TokenStream2 {
-    if let Ok(krate) = crate_name("bolero") {
-        let krate = crate_ident(krate);
-        return quote!(#krate::generator::bolero_generator);
-    }
+    // prefer referring to the generator crate, if present
     if let Ok(krate) = crate_name("bolero-generator") {
         let krate = crate_ident(krate);
         return quote!(#krate);
+    }
+    if let Ok(krate) = crate_name("bolero") {
+        let krate = crate_ident(krate);
+        return quote!(#krate::generator::bolero_generator);
     }
     panic!("current crate seems to import neither bolero nor bolero-generator, but does use the TypeGenerator derive macro")
 }

--- a/bolero-generator/src/array.rs
+++ b/bolero-generator/src/array.rs
@@ -1,122 +1,54 @@
 use crate::{Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, ValueGenerator};
 
-impl<T> TypeGenerator for [T; 0] {
-    fn generate<D_: Driver>(_driver: &mut D_) -> Option<Self> {
-        Some([])
+impl<T: TypeGenerator, const LEN: usize> TypeGenerator for [T; LEN] {
+    fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+        // TODO use core::array::try_from_fn once stable https://github.com/rust-lang/rust/issues/89379
+        let mut maybe_init: [Option<T>; LEN] = [(); LEN].map(|_| None);
+
+        for value in &mut maybe_init {
+            *value = Some(T::generate(driver)?);
+        }
+
+        Some(maybe_init.map(|t| t.unwrap()))
+    }
+
+    fn mutate<D: Driver>(&mut self, driver: &mut D) -> Option<()> {
+        for item in self {
+            item.mutate(driver)?;
+        }
+        Some(())
     }
 }
 
-impl<T> ValueGenerator for [T; 0] {
-    type Output = [T; 0];
+impl<G: ValueGenerator, const LEN: usize> ValueGenerator for [G; LEN] {
+    type Output = [G::Output; LEN];
 
-    fn generate<D_: Driver>(&self, _driver: &mut D_) -> Option<Self::Output> {
-        Some([])
+    fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
+        // TODO use core::array::try_from_fn once stable https://github.com/rust-lang/rust/issues/89379
+        let mut maybe_init: [Option<G::Output>; LEN] = [(); LEN].map(|_| None);
+
+        for (generator, value) in self.iter().zip(&mut maybe_init) {
+            *value = Some(generator.generate(driver)?);
+        }
+
+        Some(maybe_init.map(|t| t.unwrap()))
+    }
+
+    fn mutate<D: Driver>(&self, driver: &mut D, value: &mut Self::Output) -> Option<()> {
+        for (generator, value) in self.iter().zip(value) {
+            generator.mutate(driver, value)?;
+        }
+        Some(())
     }
 }
 
-impl<T> TypeGeneratorWithParams for [T; 0] {
-    type Output = [T; 0];
+impl<T: TypeGenerator, const LEN: usize> TypeGeneratorWithParams for [T; LEN] {
+    type Output = [TypeValueGenerator<T>; LEN];
 
     fn gen_with() -> Self::Output {
-        []
+        [T::gen(); LEN]
     }
 }
-
-macro_rules! impl_array {
-    ([$($acc:ident($a_value:tt),)*]) => {
-        // done
-    };
-    ($head:ident($h_index:tt), $($tail:ident($t_index:tt), )* [$($acc:ident($a_index:tt),)*]) => {
-        impl<T: TypeGenerator> TypeGenerator for [T; $h_index + 1] {
-            fn generate<D_: Driver>(driver: &mut D_) -> Option<Self> {
-                $(
-                    let $acc = T::generate(driver)?;
-                )*
-                let $head = T::generate(driver)?;
-                Some([$($acc, )* $head])
-            }
-
-            fn mutate<D_: Driver>(&mut self, driver: &mut D_) -> Option<()> {
-                $(
-                    self[$a_index].mutate(driver)?;
-                )*
-                self[$h_index].mutate(driver)?;
-                Some(())
-            }
-        }
-
-        impl<G: ValueGenerator> ValueGenerator for [G; $h_index + 1] {
-            type Output = [G::Output; $h_index + 1];
-
-            fn generate<D_: Driver>(&self, driver: &mut D_) -> Option<Self::Output> {
-                $(
-                    let $acc = self[$a_index].generate(driver)?;
-                )*
-                let $head = self[$h_index].generate(driver)?;
-                Some([$($acc, )* $head])
-            }
-
-            fn mutate<D_: Driver>(&self, driver: &mut D_, value: &mut Self::Output) -> Option<()> {
-                $(
-                    self[$a_index].mutate(driver, &mut value[$a_index])?;
-                )*
-                self[$h_index].mutate(driver, &mut value[$h_index])?;
-                Some(())
-            }
-        }
-
-        impl<T: TypeGenerator> TypeGeneratorWithParams for [T; $h_index + 1] {
-            type Output = [TypeValueGenerator<T>; $h_index + 1];
-
-            fn gen_with() -> Self::Output {
-                $(
-                    let $acc = T::gen();
-                )*
-                let $head = T::gen();
-                [$($acc, )* $head]
-            }
-        }
-
-        impl_array!($($tail($t_index),)* [$($acc($a_index),)* $head($h_index),]);
-    };
-}
-
-impl_array!(
-    a(0),
-    b(1),
-    c(2),
-    d(3),
-    e(4),
-    f(5),
-    g(6),
-    h(7),
-    i(8),
-    j(9),
-    k(10),
-    l(11),
-    m(12),
-    n(13),
-    o(14),
-    p(15),
-    q(16),
-    r(17),
-    s(18),
-    t(19),
-    u(20),
-    v(21),
-    w(22),
-    x(23),
-    y(24),
-    z(25),
-    aa(26),
-    ab(27),
-    ac(28),
-    ad(29),
-    ae(30),
-    af(31),
-    ag(32),
-    []
-);
 
 #[test]
 fn array_type_test() {

--- a/bolero-generator/src/array.rs
+++ b/bolero-generator/src/array.rs
@@ -2,7 +2,9 @@ use crate::{Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, 
 
 impl<T: TypeGenerator, const LEN: usize> TypeGenerator for [T; LEN] {
     fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-        // TODO use core::array::try_from_fn once stable https://github.com/rust-lang/rust/issues/89379
+        // TODO use core::array::try_from_fn once stable
+        //      see: https://github.com/rust-lang/rust/issues/89379
+        //      see: https://github.com/camshaft/bolero/issues/133
         let mut maybe_init: [Option<T>; LEN] = [(); LEN].map(|_| None);
 
         for value in &mut maybe_init {
@@ -24,7 +26,9 @@ impl<G: ValueGenerator, const LEN: usize> ValueGenerator for [G; LEN] {
     type Output = [G::Output; LEN];
 
     fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-        // TODO use core::array::try_from_fn once stable https://github.com/rust-lang/rust/issues/89379
+        // TODO use core::array::try_from_fn once stable
+        //      see: https://github.com/rust-lang/rust/issues/89379
+        //      see: https://github.com/camshaft/bolero/issues/133
         let mut maybe_init: [Option<G::Output>; LEN] = [(); LEN].map(|_| None);
 
         for (generator, value) in self.iter().zip(&mut maybe_init) {

--- a/bolero-generator/src/lib.rs
+++ b/bolero-generator/src/lib.rs
@@ -182,8 +182,17 @@ pub trait TypeGeneratorWithParams {
 }
 
 /// Non-parameterized ValueGenerator given a TypeGenerator
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 pub struct TypeValueGenerator<T: TypeGenerator>(PhantomData<T>);
+
+// this needs to be implemented manually so it doesn't force `T: Copy`
+impl<T: TypeGenerator> Copy for TypeValueGenerator<T> {}
+
+impl<T: TypeGenerator> Clone for TypeValueGenerator<T> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<T: TypeGenerator> Default for TypeValueGenerator<T> {
     fn default() -> Self {

--- a/bolero-generator/tests/derive_test.rs
+++ b/bolero-generator/tests/derive_test.rs
@@ -79,6 +79,11 @@ pub enum RangeOperation {
     Remove { range: RangeValue },
 }
 
+#[derive(TypeGenerator)]
+pub struct ConstGenericArray<T, const LEN: usize> {
+    value: [T; LEN],
+}
+
 #[test]
 fn derive_struct_test() {
     let _ = generator_test!(Struct::gen());


### PR DESCRIPTION
There were a few recent changes that broke the build in s2n-quic:

* In #126, the generic bounds in derives were changed and broke implementations using arbitrary sized arrays:
  ```rust
  #[derive(TypeGenerator)]
  struct Thing<T, const LEN: usize> {
    data: [T; LEN],
  }
  ```

  This is because before we generated a where clause for the whole field type:

  ```rust
  where [T; LEN]: TypeGenerator
  ```

  and now we generate it just for the generic type:

  ```rust
  where T: TypeGenerator
  ```

  To work around this, I've implemented TypeGenerator for all array lengths, which is a good idea to do anyway.
* In #109, it was set up to prioritize importing `TypeGenerator` from the `bolero` crate, if possible. This causes issues for crates like `s2n-quic-core` where we export TypeGenerator impls with a feature flag and only use `bolero` as a dev-dependency. I've swapped the priorities and this is resolved.

To try and prevent this kind of breakage in the future, I've added a workflow to test s2n-quic against any bolero changes. Note that the versions do need to match (they currently don't since the s2n-quic update is blocked on these issues) but I was able to test locally and make sure these are fixed. Moving forward, we should still be able to catch issues before bumping bolero versions.