### PR TITLE
fix: branch gen_from_bytes macro in no_std mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.57.0, 1.63.0, stable, beta, nightly]
+        rust: [1.57.0, 1.63.0, stable, nightly]
         os: [ubuntu-latest, macOS-latest]
         # TODO add honggfuzz back
-        test: [unit-tests, unit-tests-no-1.57, libfuzzer, afl, examples-tests]
+        test: [unit-tests, unit-tests-no-1.57, build-no-default-features, libfuzzer, afl, examples-tests]
         sanitizer: [NONE]
         exclude:
           - rust: 1.57.0

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 FUZZERS := libfuzzer honggfuzz afl
 endif
 
-test: unit-tests test_fuzzers examples-tests
+test: unit-tests unit-tests-no-default-features test_fuzzers examples-tests
 
 examples-tests: test_basic_example test_workspace_example
 
@@ -40,6 +40,13 @@ test_example:
 
 unit-tests:
 	cargo test
+
+build-no-default-features:
+	cd bolero-generator && cargo build --no-default-features
+	cd bolero-generator && cargo build --no-default-features --features alloc
+	cd bolero-engine && cargo build --no-default-features
+	cd bolero && cargo build --no-default-features
+	cd bolero && cargo build --no-default-features --features alloc
 
 unit-tests-no-1.57:
 	cargo test --features arbitrary

--- a/bolero-generator/src/driver/bytes.rs
+++ b/bolero-generator/src/driver/bytes.rs
@@ -43,7 +43,7 @@ impl<'a> FillBytes for ByteSliceDriver<'a> {
             }
             DriverMode::Forced => {
                 if offset < self.input.len() {
-                    let copy_len = std::cmp::min(bytes.len(), self.input.len() - offset);
+                    let copy_len = core::cmp::min(bytes.len(), self.input.len() - offset);
                     bytes[..copy_len].copy_from_slice(&self.input[offset..(offset + copy_len)]);
                     bytes[copy_len..].fill(0);
                 } else {
@@ -56,7 +56,7 @@ impl<'a> FillBytes for ByteSliceDriver<'a> {
 
     #[inline]
     fn consume_bytes(&mut self, consumed: usize) {
-        self.input = &self.input[std::cmp::min(consumed, self.input.len())..];
+        self.input = &self.input[core::cmp::min(consumed, self.input.len())..];
     }
 }
 

--- a/bolero-generator/src/driver/macros.rs
+++ b/bolero-generator/src/driver/macros.rs
@@ -91,10 +91,19 @@ macro_rules! gen_from_bytes {
             }
         }
 
+        gen_from_bytes_impl!();
+    };
+}
+
+#[cfg(feature = "alloc")]
+macro_rules! gen_from_bytes_impl {
+    () => {
         fn gen_from_bytes<Gen, T>(&mut self, len: RangeInclusive<usize>, mut gen: Gen) -> Option<T>
         where
             Gen: FnMut(&[u8]) -> Option<(usize, T)>,
         {
+            use alloc::{vec, vec::Vec};
+
             // Even attempting an alloc of more than 0x10000000000 bytes makes asan crash.
             // LibFuzzer limits memory to 2G (by default) and try_reserve() does not fail in oom situations then.
             // With all the above, limit memory allocations to 1M at a time here.
@@ -129,7 +138,7 @@ macro_rules! gen_from_bytes {
                     let init_len = len.start()
                         + self.gen_usize(
                             Bound::Included(&0),
-                            Bound::Included(&std::cmp::min(ABUSIVE_SIZE, len.end() - len.start())),
+                            Bound::Included(&core::cmp::min(ABUSIVE_SIZE, len.end() - len.start())),
                         )?;
                     let mut data = vec![0; init_len];
                     self.peek_bytes(0, &mut data)?;
@@ -140,7 +149,7 @@ macro_rules! gen_from_bytes {
                                 return Some(res);
                             }
                             None => {
-                                let max_additional_size = std::cmp::min(
+                                let max_additional_size = core::cmp::min(
                                     ABUSIVE_SIZE,
                                     len.end().saturating_sub(data.len()),
                                 );
@@ -149,7 +158,7 @@ macro_rules! gen_from_bytes {
                                     return None; // we actually tried feeding the max amount of data already
                                 }
                                 let additional_size = self.gen_usize(
-                                    Bound::Included(&std::cmp::min(
+                                    Bound::Included(&core::cmp::min(
                                         MIN_INCREASE,
                                         max_additional_size,
                                     )),
@@ -161,6 +170,38 @@ macro_rules! gen_from_bytes {
                             }
                         }
                     }
+                }
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "alloc"))]
+macro_rules! gen_from_bytes_impl {
+    () => {
+        fn gen_from_bytes<Gen, T>(&mut self, len: RangeInclusive<usize>, mut gen: Gen) -> Option<T>
+        where
+            Gen: FnMut(&[u8]) -> Option<(usize, T)>,
+        {
+            // In alloc-free mode, we can't support FORCED driver mode so just do our best to fill
+            // the data
+            const DATA_LEN: usize = 256;
+
+            let mut data = [0; DATA_LEN];
+
+            let len = match (len.start(), len.end()) {
+                (s, e) if s == e => *s,
+                (s, e) => self.gen_usize(Bound::Included(s), Bound::Included(e))?,
+            };
+            if len >= DATA_LEN {
+                return None;
+            }
+            self.peek_bytes(0, &mut data[..len])?;
+            match gen(&data[..len]) {
+                None => None,
+                Some((consumed, res)) => {
+                    self.consume_bytes(consumed);
+                    Some(res)
                 }
             }
         }


### PR DESCRIPTION
I ran into another issue when updating the s2n-quic version. In #31, we added the `gen_from_bytes` method to the driver. The default implementation used the `std` prelude and we didn't have tests for compiling the generator crate in no_std. This change fixes that.

Note that I've also removed `beta` from our test matrix since I just added another test. I don't think we get all that much benefit from it and isn't worth the CI costs.