### PR TITLE
fix: automatically set `RUSTC_BOOTSTRAP` when needed

### DIFF
--- a/cargo-bolero/Cargo.toml
+++ b/cargo-bolero/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0"
 bit-set = "0.5"
 bolero-afl = { version = "0.9", path = "../bolero-afl", default-features = false, features = ["bin"], optional = true }
 bolero-honggfuzz = { version = "0.9", path = "../bolero-honggfuzz", default-features = false, features = ["bin"], optional = true }
+console = "0.15.1"
 humantime = "2"
 lazy_static = "1"
 rustc_version = "0.4"

--- a/cargo-bolero/src/main.rs
+++ b/cargo-bolero/src/main.rs
@@ -19,6 +19,7 @@ mod reduce;
 mod selection;
 mod test;
 mod test_target;
+mod util;
 
 #[derive(Debug, StructOpt)]
 #[allow(clippy::large_enum_variant)]

--- a/cargo-bolero/src/project.rs
+++ b/cargo-bolero/src/project.rs
@@ -85,7 +85,7 @@ impl Project {
     // Determines if the toolchain channel is stable
     fn toolchain_channel_is_stable() -> bool {
         let channel = std::env::var("RUSTUP_TOOLCHAIN");
-        if !channel.is_ok() {
+        if channel.is_err() {
             return false;
         }
         channel.unwrap().contains("stable")

--- a/cargo-bolero/src/project.rs
+++ b/cargo-bolero/src/project.rs
@@ -82,7 +82,7 @@ impl Project {
         } else if Self::toolchain_channel_is_stable() {
             #[cfg(target_os = "linux")]
             {
-                PRINT_BOOTSTRAP_WARNING.call_once(|| warning("detected a stable toolchain; the variable `RUSTC_BOOTSTRAP` will be set for all commands"));
+                PRINT_BOOTSTRAP_WARNING.call_once(|| crate::util::warning("detected a stable toolchain; the variable `RUSTC_BOOTSTRAP` will be set for all commands"));
                 cmd.env("RUSTC_BOOTSTRAP", "1");
             }
         }

--- a/cargo-bolero/src/project.rs
+++ b/cargo-bolero/src/project.rs
@@ -2,11 +2,11 @@ use crate::DEFAULT_TARGET;
 use anyhow::{Context, Result};
 use core::hash::{Hash, Hasher};
 use lazy_static::lazy_static;
-use std::{collections::hash_map::DefaultHasher, process::Command};
+use rustc_version::{version_meta, Channel};
 #[cfg(target_os = "linux")]
 use std::sync::Once;
+use std::{collections::hash_map::DefaultHasher, process::Command};
 use structopt::StructOpt;
-use rustc_version::{version_meta, Channel};
 
 lazy_static! {
     static ref RUST_VERSION: rustc_version::VersionMeta = rustc_version::version_meta().unwrap();

--- a/cargo-bolero/src/project.rs
+++ b/cargo-bolero/src/project.rs
@@ -1,10 +1,9 @@
-use crate::{DEFAULT_TARGET, util::warning};
+use crate::{util::warning, DEFAULT_TARGET};
 use anyhow::{Context, Result};
 use core::hash::{Hash, Hasher};
 use lazy_static::lazy_static;
 use std::{collections::hash_map::DefaultHasher, process::Command, sync::Once};
 use structopt::StructOpt;
-
 
 lazy_static! {
     static ref RUST_VERSION: rustc_version::VersionMeta = rustc_version::version_meta().unwrap();

--- a/cargo-bolero/src/project.rs
+++ b/cargo-bolero/src/project.rs
@@ -4,6 +4,7 @@ use core::hash::{Hash, Hasher};
 use lazy_static::lazy_static;
 use std::{collections::hash_map::DefaultHasher, process::Command, sync::Once};
 use structopt::StructOpt;
+use rustc_version::{version_meta, Channel};
 
 lazy_static! {
     static ref RUST_VERSION: rustc_version::VersionMeta = rustc_version::version_meta().unwrap();
@@ -84,11 +85,11 @@ impl Project {
 
     // Determines if the toolchain channel is stable
     fn toolchain_channel_is_stable() -> bool {
-        let channel = std::env::var("RUSTUP_TOOLCHAIN");
-        if channel.is_err() {
+        let version_meta = version_meta();
+        if version_meta.is_err() {
             return false;
         }
-        channel.unwrap().contains("stable")
+        version_meta.unwrap().channel == Channel::Stable
     }
 
     fn toolchain(&self) -> &str {

--- a/cargo-bolero/src/util.rs
+++ b/cargo-bolero/src/util.rs
@@ -1,0 +1,9 @@
+//! Module that provides functions convenient for different purposes.
+
+/// Prints a styled warning message
+pub(crate) fn warning(msg: &str) {
+    let warning = console::style("warning").bold().yellow();
+    let colon = console::style(":").bold();
+    let msg_fmt = console::style(msg).bold();
+    println!("{}{} {}", warning, colon, msg_fmt);
+}

--- a/cargo-bolero/src/util.rs
+++ b/cargo-bolero/src/util.rs
@@ -1,6 +1,7 @@
 //! Module that provides functions convenient for different purposes.
 
 /// Prints a styled warning message
+#[cfg(target_os = "linux")]
 pub(crate) fn warning(msg: &str) {
     let warning = console::style("warning").bold().yellow();
     let colon = console::style(":").bold();


### PR DESCRIPTION
Most `cargo bolero` commands use nightly options (i.e., `-Zsanitizer`) which require a nightly toolchain. Running such commands with a stable toolchain will lead to this error:

```
Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --cfg fuzzing -Cdebug-assertions <...>` (exit status: 1)
  --- stderr
  error: the option `Z` is only accepted on the nightly compiler
```

In this PR, we make an effort to automatically set `RUSTC_BOOTSTRAP` if we're running on a stable toolchain, removing the need to pass `--rustc-bootstrap` each time we use `cargo bolero` in a project with a stable toolchain. We'll also print a warning for users to be aware of this:

```
warning: detected a stable toolchain, will automatically set `RUSTC_BOOTSTRAP`
```

The warning was being printed multiple times since bolero would build several commands, so I used `Once` to ensure it's only printed once.

Unfortunately, the `RUSTC_BOOTSTRAP` trick doesn't work on platforms such as macOS, where the crash continues to happen.