### PR TITLE
Replace `if cfg!(kani)` by `#[cfg(kani)]`

### DIFF
--- a/bolero-engine/src/target_location.rs
+++ b/bolero-engine/src/target_location.rs
@@ -28,20 +28,18 @@ pub struct TargetLocation {
 
 impl TargetLocation {
     pub fn should_run(&self) -> bool {
-        if cfg!(kani) {
-            return true;
-        }
-
-        // cargo-bolero needs to resolve information about the target
-        if let Ok(mode) = ::std::env::var("CARGO_BOLERO_SELECT") {
-            match mode.as_str() {
-                "all" => self.print(),
-                "one" if self.is_exact_match() => self.print(),
-                _ => {}
+        #[cfg(not(kani))]
+        {
+            // cargo-bolero needs to resolve information about the target
+            if let Ok(mode) = ::std::env::var("CARGO_BOLERO_SELECT") {
+                match mode.as_str() {
+                    "all" => self.print(),
+                    "one" if self.is_exact_match() => self.print(),
+                    _ => {}
+                }
+                return false;
             }
-            return false;
         }
-
         true
     }
 
@@ -65,59 +63,72 @@ impl TargetLocation {
     }
 
     pub fn abs_path(&self) -> Option<PathBuf> {
-        if cfg!(kani) {
-            return None;
-        }
-
-        let file = Path::new(self.file);
-
-        #[cfg(not(miri))] // miri does not currently support this call
+        #[cfg(kani)]
         {
-            if let Ok(file) = file.canonicalize() {
-                return Some(file);
-            }
+            None
         }
 
-        Path::new(self.manifest_dir)
-            .ancestors()
-            .find_map(|ancestor| {
-                let path = ancestor.join(file);
-                if path.exists() {
-                    Some(path)
-                } else {
-                    None
+        #[cfg(not(kani))]
+        {
+            let file = Path::new(self.file);
+
+            #[cfg(not(miri))] // miri does not currently support this call
+            {
+                if let Ok(file) = file.canonicalize() {
+                    return Some(file);
                 }
-            })
+            }
+
+            Path::new(self.manifest_dir)
+                .ancestors()
+                .find_map(|ancestor| {
+                    let path = ancestor.join(file);
+                    if path.exists() {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+        }
     }
 
     pub fn work_dir(&self) -> Option<PathBuf> {
-        if cfg!(kani) {
-            return None;
+        #[cfg(kani)]
+        {
+            None
         }
 
-        let mut work_dir = self.abs_path()?;
-        work_dir.pop();
+        #[cfg(not(kani))]
+        {
 
-        if !self.is_harnessed() {
-            return Some(work_dir);
+            let mut work_dir = self.abs_path()?;
+            work_dir.pop();
+
+            if !self.is_harnessed() {
+                return Some(work_dir);
+            }
+
+            work_dir.push("__fuzz__");
+            if let Some(test_name) = self.test_name.as_ref() {
+                work_dir.push(test_name);
+            } else {
+                work_dir.push(self.fuzz_dir());
+            }
+
+            Some(work_dir)
         }
-
-        work_dir.push("__fuzz__");
-        if let Some(test_name) = self.test_name.as_ref() {
-            work_dir.push(test_name);
-        } else {
-            work_dir.push(self.fuzz_dir());
-        }
-
-        Some(work_dir)
     }
 
     pub fn is_harnessed(&self) -> bool {
-        if cfg!(kani) {
-            return false;
+        #[cfg(kani)]
+        {
+            false
         }
 
-        is_harnessed(self.item_path)
+        #[cfg(not(kani))]
+        {
+            is_harnessed(self.item_path)
+        }
     }
 
     fn fuzz_dir(&self) -> String {

--- a/bolero-engine/src/target_location.rs
+++ b/bolero-engine/src/target_location.rs
@@ -100,7 +100,6 @@ impl TargetLocation {
 
         #[cfg(not(kani))]
         {
-
             let mut work_dir = self.abs_path()?;
             work_dir.pop();
 


### PR DESCRIPTION
In previous version of rustc, they would have similar behavior even in debug mode, where all the logic from a `false` evaluation would be pruned.

This is no longer true in the current rustc release candidate. I created [this thread](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.60if.20cfg!.28false.29.60.20no.20longer.20pruned.20from.20debug.20build) to see if this was by design or if it's a bug.

That said, this is currently blocking the [Kani toolchain upgrade PR](https://github.com/model-checking/kani/pull/2406), so I was hoping we could switch the definition. Thanks!