### PR TITLE
feat: replace the --release flag with a generic --profile flag 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ members = [
     "cargo-bolero",
 ]
 
+[profile.fuzz]
+inherits = "dev"
+opt-level = 3
+incremental = false
+codegen-units = 1
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -59,7 +59,7 @@ libfuzzer honggfuzz:
 	    fuzz_bytes \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -68,7 +68,7 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release true \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -76,7 +76,7 @@ libfuzzer honggfuzz:
 	    fuzz_generator \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -85,7 +85,7 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 1000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -93,7 +93,7 @@ libfuzzer honggfuzz:
 	    fuzz_operations \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@SHOULD_PANIC=1 cargo run \
 	    --features $@ \
@@ -102,7 +102,7 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -111,7 +111,7 @@ libfuzzer honggfuzz:
 	    tests::add_test \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -121,7 +121,7 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -130,7 +130,7 @@ libfuzzer honggfuzz:
 	    tests::other_test \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -140,7 +140,7 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 1000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 
@@ -152,7 +152,7 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -161,7 +161,7 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@rm -rf examples/basic/src/__fuzz__
 	@SHOULD_PANIC=1 cargo run \
@@ -171,7 +171,7 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    && exit 1 || true
 	@rm -rf examples/basic/src/__fuzz__
@@ -182,7 +182,7 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --release \
+	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    && exit 1 || true
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -59,7 +58,6 @@ libfuzzer honggfuzz:
 	    fuzz_bytes \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -68,7 +66,6 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -76,7 +73,6 @@ libfuzzer honggfuzz:
 	    fuzz_generator \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -85,7 +81,6 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 1000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -93,7 +88,6 @@ libfuzzer honggfuzz:
 	    fuzz_operations \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@SHOULD_PANIC=1 cargo run \
 	    --features $@ \
@@ -102,7 +96,6 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -111,7 +104,6 @@ libfuzzer honggfuzz:
 	    tests::add_test \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -121,7 +113,6 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -130,7 +121,6 @@ libfuzzer honggfuzz:
 	    tests::other_test \
 	    --manifest-path examples/basic/Cargo.toml \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 	@SHOULD_PANIC=1 cargo run \
@@ -140,7 +130,6 @@ libfuzzer honggfuzz:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 1000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    || true # TODO make this consistent
 
@@ -152,7 +141,6 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@cargo run \
 	    --features $@ \
@@ -161,7 +149,6 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER)
 	@rm -rf examples/basic/src/__fuzz__
 	@SHOULD_PANIC=1 cargo run \
@@ -171,7 +158,6 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    && exit 1 || true
 	@rm -rf examples/basic/src/__fuzz__
@@ -182,7 +168,6 @@ afl:
 	    --manifest-path examples/basic/Cargo.toml \
 	    --runs 100000 \
 	    --engine $@ \
-	    --profile release \
 	    --sanitizer $(SANITIZER) \
 	    && exit 1 || true
 

--- a/book/src/library-installation.md
+++ b/book/src/library-installation.md
@@ -13,12 +13,13 @@ bolero = "0.8"
 ```
 to `Cargo.toml`.
 
-Then, create the `fuzz` profile:
+Then, create the `fuzz` profile: (Note that LTO is not well-supported for the fuzzing profile)
 ```toml
 [profile.fuzz]
-inherits = "release"
+inherits = "debug"
+opt-level = 3
+incremental = false
 codegen-units = 1
-debug-assertions = true
 ```
 
 ## Structured Test Generation

--- a/book/src/library-installation.md
+++ b/book/src/library-installation.md
@@ -16,7 +16,7 @@ to `Cargo.toml`.
 Then, create the `fuzz` profile: (Note that LTO is not well-supported for the fuzzing profile)
 ```toml
 [profile.fuzz]
-inherits = "debug"
+inherits = "dev"
 opt-level = 3
 incremental = false
 codegen-units = 1

--- a/book/src/library-installation.md
+++ b/book/src/library-installation.md
@@ -22,6 +22,11 @@ incremental = false
 codegen-units = 1
 ```
 
+If you forget adding the profile, then you will get the following error:
+```
+error: profile `fuzz` is not defined
+```
+
 ## Structured Test Generation
 
 If your crate wishes to implement structured test generation on public data structures, `bolero-generator` can be added to the main dependencies:

--- a/book/src/library-installation.md
+++ b/book/src/library-installation.md
@@ -13,6 +13,14 @@ bolero = "0.8"
 ```
 to `Cargo.toml`.
 
+Then, create the `fuzz` profile:
+```toml
+[profile.fuzz]
+inherits = "release"
+codegen-units = 1
+debug-assertions = true
+```
+
 ## Structured Test Generation
 
 If your crate wishes to implement structured test generation on public data structures, `bolero-generator` can be added to the main dependencies:

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -30,3 +30,9 @@ harness = false
 
 [profile.bench]
 debug = true
+
+[profile.fuzz]
+inherits = "dev"
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -3,3 +3,9 @@ members = ["crate_a", "crate_b"]
 
 [profile.bench]
 debug = true
+
+[profile.fuzz]
+inherits = "dev"
+opt-level = 3
+incremental = false
+codegen-units = 1


### PR DESCRIPTION
Also make the default profile "fuzz", and document that it should probably have codegen-units set to 1, in replacement to the semi-fix that had been implemented only when the release mode was set.

The drawback of this change is it forces people to have a `fuzz` profile by default, and to add `codegen-units = 1` themselves. I think it is a good thing that said, because of rust’s philosophy of "better explicit than implicit" and the fact that 3 lines per crate are not too much boilerplate:
```rust
[profile.fuzz]
inherits = "release"
codegen-units = 1
debug-assertions = true # not strictly speaking necessary, but I think it’s useful
```

The big advantage is, it makes it much easier to eg. turn debug assertions on or off, and people can always use `--profile release` if they want to build in regular release mode (though then they’ll probably hit the `codegen-units` issue).

WDYT?