### PR TITLE
fix: address clippy warnings

### DIFF
--- a/bolero-generator/src/lib.rs
+++ b/bolero-generator/src/lib.rs
@@ -190,7 +190,7 @@ impl<T: TypeGenerator> Copy for TypeValueGenerator<T> {}
 
 impl<T: TypeGenerator> Clone for TypeValueGenerator<T> {
     fn clone(&self) -> Self {
-        Self(PhantomData)
+        *self
     }
 }
 

--- a/bolero-generator/src/range.rs
+++ b/bolero-generator/src/range.rs
@@ -1,7 +1,7 @@
 use crate::{Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, ValueGenerator};
 
 macro_rules! range_generator {
-    ($ty:ident, $generator:ident, $new:expr) => {
+    ($ty:ident, $generator:ident, | $start:ident, $end:ident | $new:expr) => {
         pub struct $generator<Start, End> {
             start: Start,
             end: End,
@@ -61,19 +61,17 @@ macro_rules! range_generator {
             type Output = core::ops::$ty<T>;
 
             fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-                let start = self.start.generate(driver)?;
-                let end = self.end.generate(driver)?;
-                #[allow(clippy::redundant_closure)]
-                Some($new(start, end))
+                let $start = self.start.generate(driver)?;
+                let $end = self.end.generate(driver)?;
+                Some($new)
             }
         }
 
         impl<T: TypeGenerator> TypeGenerator for core::ops::$ty<T> {
             fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-                let start = driver.gen()?;
-                let end = driver.gen()?;
-                #[allow(clippy::redundant_closure)]
-                Some($new(start, end))
+                let $start = driver.gen()?;
+                let $end = driver.gen()?;
+                Some($new)
             }
         }
 

--- a/bolero-kani/src/lib.rs
+++ b/bolero-kani/src/lib.rs
@@ -39,7 +39,7 @@ pub mod lib {
 
     impl KaniEngine {
         pub fn new(_location: TargetLocation) -> Self {
-            Self::default()
+            Self
         }
     }
 

--- a/bolero-libfuzzer/src/lib.rs
+++ b/bolero-libfuzzer/src/lib.rs
@@ -19,7 +19,9 @@ pub mod fuzzer {
         pub fn LLVMFuzzerStartTest(a: c_int, b: *const *const c_char) -> c_int;
     }
 
-    static mut TESTFN: Option<&mut dyn FnMut(&[u8]) -> bool> = None;
+    type TestFn<'a> = &'a mut dyn FnMut(&[u8]) -> bool;
+
+    static mut TESTFN: Option<TestFn> = None;
 
     #[derive(Debug, Default)]
     pub struct LibFuzzerEngine {


### PR DESCRIPTION
This fixes the latest clippy warnings, which are now passing: https://github.com/camshaft/bolero/actions/runs/6132949824/job/16644342393?pr=174