### PR TITLE
fix: patch libfuzzer to support jobs argument

### DIFF
--- a/lib/bolero-libfuzzer/bolero-fixes.patch
+++ b/lib/bolero-libfuzzer/bolero-fixes.patch
@@ -1,0 +1,48 @@
+diff -ruN libfuzzer/FuzzerCommand.h b/libfuzzer/FuzzerCommand.h
+index f653fe3..678573e 100644
+--- libfuzzer/FuzzerCommand.h
++++ b/libfuzzer/FuzzerCommand.h
+@@ -139,16 +139,35 @@ public:
+   // be the equivalent command line.
+   std::string toString() const {
+     std::stringstream SS;
+-    for (auto arg : getArguments())
+-      SS << arg << " ";
++    auto test_name = std::getenv("BOLERO_TEST_NAME");
++    auto libtest_harness = std::getenv("BOLERO_LIBTEST_HARNESS");
++    auto args = getArguments();
++
++    SS << "env";
++
++    if (libtest_harness) {
++      SS << " BOLERO_LIBTEST_HARNESS=1 BOLERO_TEST_NAME=\"" << test_name << "\"";
++    }
++
++    SS << " BOLERO_LIBFUZZER_ARGS=\"";
++    if (args.size() > 1)
++      SS << args[1];
++    for (unsigned i = 2; i < args.size(); ++i)
++      SS << " " << args[i];
++    SS << "\"";
++
++    SS << " " << args[0];
++
++    if (libtest_harness) {
++      SS << " " << test_name << " --exact --nocapture --quiet --test-threads 1";
++    }
++
+     if (hasOutputFile())
+-      SS << ">" << getOutputFile() << " ";
++      SS << " >" << getOutputFile();
+     if (isOutAndErrCombined())
+-      SS << "2>&1 ";
+-    std::string result = SS.str();
+-    if (!result.empty())
+-      result = result.substr(0, result.length() - 1);
+-    return result;
++      SS << " 2>&1";
++
++    return SS.str();
+   }
+ 
+ private:

--- a/lib/bolero-libfuzzer/build.rs
+++ b/lib/bolero-libfuzzer/build.rs
@@ -3,6 +3,7 @@ extern crate cc;
 fn main() {
     println!("cargo:rerun-if-env-changed=BOLERO_FUZZER");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_FUZZING_LIBFUZZER");
+    println!("cargo:rerun-if-changed=libfuzzer/");
 
     if std::env::var("CARGO_CFG_FUZZING_LIBFUZZER").is_ok() {
         let mut build = cc::Build::new();

--- a/lib/bolero-libfuzzer/libfuzzer/FuzzerCommand.h
+++ b/lib/bolero-libfuzzer/libfuzzer/FuzzerCommand.h
@@ -139,16 +139,35 @@ public:
   // be the equivalent command line.
   std::string toString() const {
     std::stringstream SS;
-    for (auto arg : getArguments())
-      SS << arg << " ";
+    auto test_name = std::getenv("BOLERO_TEST_NAME");
+    auto libtest_harness = std::getenv("BOLERO_LIBTEST_HARNESS");
+    auto args = getArguments();
+
+    SS << "env";
+
+    if (libtest_harness) {
+      SS << " BOLERO_LIBTEST_HARNESS=1 BOLERO_TEST_NAME=\"" << test_name << "\"";
+    }
+
+    SS << " BOLERO_LIBFUZZER_ARGS=\"";
+    if (args.size() > 1)
+      SS << args[1];
+    for (unsigned i = 2; i < args.size(); ++i)
+      SS << " " << args[i];
+    SS << "\"";
+
+    SS << " " << args[0];
+
+    if (libtest_harness) {
+      SS << " " << test_name << " --exact --nocapture --quiet --test-threads 1";
+    }
+
     if (hasOutputFile())
-      SS << ">" << getOutputFile() << " ";
+      SS << " >" << getOutputFile();
     if (isOutAndErrCombined())
-      SS << "2>&1 ";
-    std::string result = SS.str();
-    if (!result.empty())
-      result = result.substr(0, result.length() - 1);
-    return result;
+      SS << " 2>&1";
+
+    return SS.str();
   }
 
 private:

--- a/lib/bolero-libfuzzer/src/lib.rs
+++ b/lib/bolero-libfuzzer/src/lib.rs
@@ -93,12 +93,23 @@ pub mod fuzzer {
             ));
         }
 
-        if std::env::var("__BOLERO_LIBFUZZER_RECURSE").is_ok() {
+        // Libfuzzer can generate multiple jobs that can make the binary recurse.
+        // Still, let’s limit recursion depth to some reasonable amount.
+        let recursion_level = std::env::var("__BOLERO_LIBFUZZER_RECURSE")
+            .as_deref()
+            .unwrap_or("0")
+            .parse()
+            .unwrap_or(usize::MAX);
+
+        if recursion_level > 10 {
             eprintln!("LOOPING BINARY");
             std::process::exit(1);
         }
 
-        std::env::set_var("__BOLERO_LIBFUZZER_RECURSE", "1");
+        std::env::set_var(
+            "__BOLERO_LIBFUZZER_RECURSE",
+            (recursion_level + 1).to_string(),
+        );
 
         // create a vector of NULL terminated strings
         let args = std::env::args()

--- a/lib/bolero-libfuzzer/update.sh
+++ b/lib/bolero-libfuzzer/update.sh
@@ -10,3 +10,4 @@ git clone --depth 1 --single-branch --branch $version https://github.com/llvm/ll
 rm -rf "$project_dir/libfuzzer/"
 mv "$tmp_dir/compiler-rt/lib/fuzzer/" "$project_dir/libfuzzer"
 mv "$tmp_dir/compiler-rt/LICENSE.TXT" "$project_dir/libfuzzer/LICENSE.TXT"
+patch -p0 < bolero-fixes.patch


### PR DESCRIPTION
This is a similar change as #161, but limits the size of the patch to the single `toString` function.


There seems to be an issue with exit code propagation and the `--jobs` argument. The test seems to be exiting without an error. We'll need to investigate why that it is.