### PR TITLE
fix(bolero-generator)!: remove map/filter/and_then to avoid conflicts with Iterator

### DIFF
--- a/lib/bolero-engine/src/shrink/tests.rs
+++ b/lib/bolero-engine/src/shrink/tests.rs
@@ -38,7 +38,7 @@ shrink_test!(u32_shrink_test, gen::<u32>(), [255u8; 4], 20, |value| {
 
 shrink_test!(
     vec_shrink_test,
-    gen::<Vec<u32>>().filter(|vec| vec.len() >= 3),
+    gen::<Vec<u32>>().filter_gen(|vec| vec.len() >= 3),
     [255u8; 256],
     vec![4, 0, 0],
     |value: Vec<u32>| {
@@ -50,7 +50,7 @@ shrink_test!(
 
 shrink_test!(
     non_start_vec_shrink_test,
-    gen::<Vec<u32>>().filter(|vec| vec.len() >= 3),
+    gen::<Vec<u32>>().filter_gen(|vec| vec.len() >= 3),
     [255u8; 256],
     vec![0, 5, 0],
     |value: Vec<u32>| {
@@ -61,7 +61,7 @@ shrink_test!(
 
 shrink_test!(
     middle_vec_shrink_test,
-    gen::<Vec<u8>>().filter(|vec| vec.len() >= 3),
+    gen::<Vec<u8>>().filter_gen(|vec| vec.len() >= 3),
     [255u8; 256],
     vec![1, 1, 1],
     |value: Vec<u8>| {

--- a/lib/bolero-generator/src/combinator.rs
+++ b/lib/bolero-generator/src/combinator.rs
@@ -17,7 +17,7 @@ impl<G: ValueGenerator, M: Fn(G::Output) -> T, T> ValueGenerator for MapGenerato
 
 #[test]
 fn map_test() {
-    let _ = generator_test!(gen::<u8>().map(|value| value > 4));
+    let _ = generator_test!(gen::<u8>().map_gen(|value| value > 4));
 }
 
 #[derive(Clone, Debug)]
@@ -39,7 +39,7 @@ impl<G: ValueGenerator, H: ValueGenerator, F: Fn(G::Output) -> H> ValueGenerator
 
 #[test]
 fn and_then_test() {
-    let _ = generator_test!(gen::<u8>().and_then(|value| value..));
+    let _ = generator_test!(gen::<u8>().and_then_gen(|value| value..));
 }
 
 #[derive(Clone, Debug)]
@@ -63,7 +63,7 @@ impl<G: ValueGenerator, F: Fn(&G::Output) -> bool> ValueGenerator for FilterGene
 
 #[test]
 fn filter_test() {
-    let _ = generator_test!(gen::<u8>().filter(|value| *value > 40));
+    let _ = generator_test!(gen::<u8>().filter_gen(|value| *value > 40));
 }
 
 #[derive(Clone, Debug)]
@@ -85,5 +85,5 @@ impl<G: ValueGenerator, F: Fn(G::Output) -> Option<T>, T> ValueGenerator
 
 #[test]
 fn filter_map_test() {
-    let _ = generator_test!(gen::<u8>().filter_map(|value| Some(value > 40)));
+    let _ = generator_test!(gen::<u8>().filter_map_gen(|value| Some(value > 40)));
 }

--- a/lib/bolero-generator/src/lib.rs
+++ b/lib/bolero-generator/src/lib.rs
@@ -82,15 +82,6 @@ pub trait ValueGenerator: Sized {
     }
 
     /// Map the value of a generator
-    fn map<F: Fn(Self::Output) -> T, T>(self, map: F) -> MapGenerator<Self, F> {
-        MapGenerator {
-            generator: self,
-            map,
-        }
-    }
-
-    /// Map the value of a generator, exists to reduce conflicts with
-    /// other `map` functions.
     fn map_gen<F: Fn(Self::Output) -> T, T>(self, map: F) -> MapGenerator<Self, F> {
         MapGenerator {
             generator: self,
@@ -99,18 +90,6 @@ pub trait ValueGenerator: Sized {
     }
 
     /// Map the value of a generator with a new generator
-    fn and_then<F: Fn(Self::Output) -> T, T: ValueGenerator>(
-        self,
-        and_then: F,
-    ) -> AndThenGenerator<Self, F> {
-        AndThenGenerator {
-            generator: self,
-            and_then,
-        }
-    }
-
-    /// Map the value of a generator with a new generator, exists to
-    /// reduce conflicts with other `map` functions.
     fn and_then_gen<F: Fn(Self::Output) -> T, T: ValueGenerator>(
         self,
         and_then: F,
@@ -122,15 +101,6 @@ pub trait ValueGenerator: Sized {
     }
 
     /// Filter the value of a generator
-    fn filter<F: Fn(&Self::Output) -> bool>(self, filter: F) -> FilterGenerator<Self, F> {
-        FilterGenerator {
-            generator: self,
-            filter,
-        }
-    }
-
-    /// Filter the value of a generator, exists to
-    /// reduce conflicts with other `filter` functions.
     fn filter_gen<F: Fn(&Self::Output) -> bool>(self, filter: F) -> FilterGenerator<Self, F> {
         FilterGenerator {
             generator: self,
@@ -139,18 +109,6 @@ pub trait ValueGenerator: Sized {
     }
 
     /// Filter the value of a generator and map it to something else
-    fn filter_map<F: Fn(Self::Output) -> Option<T>, T>(
-        self,
-        filter_map: F,
-    ) -> FilterMapGenerator<Self, F> {
-        FilterMapGenerator {
-            generator: self,
-            filter_map,
-        }
-    }
-
-    /// Filter the value of a generator and map it to something else, exists to
-    /// reduce conflicts with other `filter_map` functions.
     fn filter_map_gen<F: Fn(Self::Output) -> Option<T>, T>(
         self,
         filter_map: F,

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -291,7 +291,7 @@ impl<G: generator::ValueGenerator, Engine, InputOwnership> TestTarget<G, Engine,
         map: F,
     ) -> TestTarget<MapGenerator<G, F>, Engine, InputOwnership> {
         TestTarget {
-            generator: self.generator.map(map),
+            generator: self.generator.map_gen(map),
             engine: self.engine,
             driver_options: self.driver_options,
             input_ownership: self.input_ownership,
@@ -307,7 +307,7 @@ impl<G: generator::ValueGenerator, Engine, InputOwnership> TestTarget<G, Engine,
         T::Output: Debug,
     {
         TestTarget {
-            generator: self.generator.and_then(map),
+            generator: self.generator.and_then_gen(map),
             engine: self.engine,
             driver_options: self.driver_options,
             input_ownership: self.input_ownership,
@@ -320,7 +320,7 @@ impl<G: generator::ValueGenerator, Engine, InputOwnership> TestTarget<G, Engine,
         filter: F,
     ) -> TestTarget<FilterGenerator<G, F>, Engine, InputOwnership> {
         TestTarget {
-            generator: self.generator.filter(filter),
+            generator: self.generator.filter_gen(filter),
             engine: self.engine,
             driver_options: self.driver_options,
             input_ownership: self.input_ownership,
@@ -333,7 +333,7 @@ impl<G: generator::ValueGenerator, Engine, InputOwnership> TestTarget<G, Engine,
         filter_map: F,
     ) -> TestTarget<FilterMapGenerator<G, F>, Engine, InputOwnership> {
         TestTarget {
-            generator: self.generator.filter_map(filter_map),
+            generator: self.generator.filter_map_gen(filter_map),
             engine: self.engine,
             driver_options: self.driver_options,
             input_ownership: self.input_ownership,


### PR DESCRIPTION
**Breaking change**

This PR removes the `map`/`filter`/`and_then` methods from the `ValueGenerator` trait. When trying to use these methods on types that implement `Iterator` it creates conflicts that are annoying to work around:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0eac7ac05e98d4ae46bdbfe644ddb662

```rust
error[E0034]: multiple applicable items in scope
  --> src/main.rs:12:20
   |
12 |     let _ = (0..1).map(|v| v);
   |                    ^^^ multiple `map` found
   |
note: candidate #1 is defined in an impl of the trait `ValueGenerator` for the type `std::ops::Range<u64>`
  --> src/main.rs:2:5
   |
2  |     fn map<F>(self, f: F) -> Self {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: candidate #2 is defined in an impl of the trait `Iterator` for the type `std::ops::Range<A>`
help: disambiguate the method for candidate #1
   |
12 |     let _ = ValueGenerator::map((0..1), |v| v);
   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the method for candidate #2
   |
12 |     let _ = Iterator::map((0..1), |v| v);
   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```