### PR TITLE
fix(bolero-kani): use cover instead of assume

### DIFF
--- a/lib/bolero-kani/src/lib.rs
+++ b/lib/bolero-kani/src/lib.rs
@@ -51,8 +51,13 @@ pub mod lib {
             let mut input = KaniInput { options };
             match test.test(&mut input) {
                 Ok(was_valid) => {
-                    // make sure the input that we generated was valid
-                    kani::assume(was_valid);
+                    // show if the generator was satisfiable
+                    // TODO fail the harness if it's not: https://github.com/model-checking/kani/issues/2792
+                    #[cfg(kani)]
+                    kani::cover!(
+                        was_valid,
+                        "the generator should produce at least one valid value"
+                    );
                 }
                 Err(_) => {
                     panic!("test failed");


### PR DESCRIPTION
We currently use `kani::assume(was_valid)` on the generator result. This isn't really what we want, since kani won't actually fail the proof if an assumption is unsatisfiable; see https://github.com/model-checking/kani/issues/2693.

Instead, the `cover!` macro is somewhat closer to what we want. It at least reports if the `was_valid` variable was ever true. Ideally, it would fail the proof so I've opened an issue for that: https://github.com/model-checking/kani/issues/2792.