### PR TITLE
fix: actually limit the time taken to shrink

### DIFF
--- a/lib/bolero-engine/src/shrink.rs
+++ b/lib/bolero-engine/src/shrink.rs
@@ -96,6 +96,11 @@ impl<'a, T: Test> Shrinker<'a, T> {
                 }
 
                 self.apply_transforms(index, &mut was_changed);
+
+                // put a time limit on the number of shrink attempts
+                if start_time.elapsed() > shrink_time {
+                    break;
+                }
             }
 
             // we made it through all of the transforms without shrinking


### PR DESCRIPTION
I have a case where there is a 4kiB input that needs shrinking. Bolero then wants to run 4000 times the apply_transforms function before checking for shrink time.

Unfortunately, each apply_transforms seems to run my test closure 2000 times, and each test closure takes 50-100ms to run.

All together, bolero would need 9 days before checking for the shrink time limit for the first time.

With this change, bolero now checks more often the shrink time, which actually leads to me getting an error message and not what looks like a deadlock :)

----

I'll also ask, do you think you could release 0.10.1 with the fixes? It's probably not the first time I've hit the bug, but until now I've been ignoring it due to it looking like a deadlock.