### PR TITLE
allow bolero tests to run on wasm32-unknown-unknown

### DIFF
--- a/lib/bolero/src/test/input.rs
+++ b/lib/bolero/src/test/input.rs
@@ -5,6 +5,7 @@ use bolero_generator::{driver, TypeGenerator};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{io::Read, path::PathBuf};
 
+#[cfg_attr(target_os = "unknown", allow(dead_code))]
 pub enum TestInput {
     FileTest(FileTest),
     RngTest(RngTest),
@@ -19,6 +20,7 @@ impl TestInput {
     }
 }
 
+#[cfg_attr(target_os = "unknown", allow(dead_code))]
 pub struct FileTest {
     pub path: PathBuf,
 }


### PR DESCRIPTION
This PR allows cargo-bolero to run `bolero::check!()` tests on wasm32-unknown-unknown.

This is not fuzzing yet, but at least basic proptesting works there, with this PR :)

Considering the infrastructure required for testing (all the wasm-bindgen stuff), I'm not submitting a new test here; but I checked on the repo with my use case that a test that takes an `u8` and matches for `!= 4` did fail as expected.