### PR TITLE
avoid infinite loop with invalid objects

### DIFF
--- a/lib/bolero-generator/src/arbitrary.rs
+++ b/lib/bolero-generator/src/arbitrary.rs
@@ -80,4 +80,22 @@ mod tests {
     fn vec() {
         let _ = generator_test!(gen_arbitrary::<Vec<usize>>());
     }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct UnlikelyToBeValid(u128);
+
+    impl<'a> arbitrary::Arbitrary<'a> for UnlikelyToBeValid {
+        fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<UnlikelyToBeValid> {
+            let v = u.arbitrary::<u128>()?;
+            if v >= 1024 {
+                return Err(arbitrary::Error::IncorrectFormat);
+            }
+            Ok(UnlikelyToBeValid(v))
+        }
+    }
+
+    #[test]
+    fn unlikely_to_be_valid() {
+        let _ = generator_test!(gen_arbitrary::<UnlikelyToBeValid>());
+    }
 }

--- a/lib/bolero-generator/src/driver/rng.rs
+++ b/lib/bolero-generator/src/driver/rng.rs
@@ -116,7 +116,7 @@ impl<R: RngCore> Driver for Rng<R> {
     {
         // Even attempting an alloc of more than 0x10000000000 bytes makes asan crash.
         // LibFuzzer limits memory to 2G (by default) and try_reserve() does not fail in oom situations then.
-        // With all the above, limit memory allocations to 1M at a time here.
+        // With all the above, limit memory allocations to 1M total here.
         const NONSENSICAL_SIZE: usize = 1024 * 1024;
         const ABUSIVE_SIZE: usize = 1024;
         const MIN_INCREASE: usize = 32;
@@ -166,6 +166,9 @@ impl<R: RngCore> Driver for Rng<R> {
                                 Bound::Included(&max_additional_size),
                             )?;
                             len += additional_size;
+                            if len >= NONSENSICAL_SIZE {
+                                return None;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Actually check for NONSENSICAL_SIZE when in DriverMode::Forced, and introduce a regression test.