### PR TITLE
replace with_iterations with with_test_time

### DIFF
--- a/bin/cargo-bolero/src/random.rs
+++ b/bin/cargo-bolero/src/random.rs
@@ -19,6 +19,9 @@ pub(crate) fn test(selection: &Selection, test_args: &test::Args) -> Result<()> 
     optional_arg!(seed, "BOLERO_RANDOM_SEED");
     optional_arg!(runs, "BOLERO_RANDOM_ITERATIONS");
     optional_arg!(max_input_length, "BOLERO_RANDOM_MAX_LEN");
+    if let Some(t) = test_args.time {
+        cmd.env("BOLERO_RANDOM_TEST_TIME_MS", t.as_millis().to_string());
+    }
 
     // TODO implement other options
     /*

--- a/lib/bolero-engine/src/rng.rs
+++ b/lib/bolero-engine/src/rng.rs
@@ -26,7 +26,7 @@ impl Options {
     pub fn test_time_or_default(&self) -> Duration {
         self.test_time.unwrap_or_else(|| {
             if self.iterations.is_some() {
-                Duration::from_secs(3600 * 24 * 365 * 100)
+                Duration::MAX
             } else {
                 Duration::from_secs(1)
             }

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -358,6 +358,12 @@ impl<G: generator::ValueGenerator, Engine, InputOwnership> TestTarget<G, Engine,
 cfg_if::cfg_if! {
     if #[cfg(any(fuzzing, kani))] {
         impl<G, Engine, InputOwnership> TestTarget<G, Engine, InputOwnership> {
+            /// Set the maximum runtime of the tests
+            pub fn with_test_time(self, test_time: Duration) -> Self {
+                let _ = test_time;
+                self
+            }
+
             /// Set the number of iterations executed
             pub fn with_iterations(self, iterations: usize) -> Self {
                 let _ = iterations;
@@ -372,6 +378,12 @@ cfg_if::cfg_if! {
         }
     } else {
         impl<G, InputOwnership> TestTarget<G, crate::test::TestEngine, InputOwnership> {
+            /// Set the maximum runtime of the tests
+            pub fn with_test_time(mut self, test_time: Duration) -> Self {
+                self.engine.with_test_time(test_time);
+                self
+            }
+
             /// Set the number of iterations executed
             pub fn with_iterations(mut self, iterations: usize) -> Self {
                 self.engine.with_iterations(iterations);

--- a/lib/bolero/src/tests.rs
+++ b/lib/bolero/src/tests.rs
@@ -53,7 +53,7 @@ fn range_generator_cloned_test() {
 #[test]
 fn nested_test() {
     check!().with_generator(0..=5).for_each(|_input: &u8| {
-        // println!("{:?}", input);
+        // println!("{:?}", _input);
     });
 }
 
@@ -66,4 +66,17 @@ fn iteration_number() {
         num_iters.fetch_add(1, Ordering::Relaxed);
     });
     assert_eq!(num_iters.load(Ordering::Relaxed), 5);
+}
+
+#[test]
+fn with_test_time() {
+    // Atomic to avoid having to think about unwind safety
+    use std::sync::atomic::Ordering;
+    let num_iters = std::sync::atomic::AtomicUsize::new(0);
+    check!()
+        .with_test_time(core::time::Duration::from_millis(5))
+        .for_each(|_| {
+            num_iters.fetch_add(1, Ordering::Relaxed);
+        });
+    assert!(num_iters.load(Ordering::Relaxed) > 10);
 }


### PR DESCRIPTION
I've noticed that some of my bolero tests are very unbelievably slow to run. This is because bolero runs through the whole local corpus on each run, and my tests are fundamentally slow (~10 execs / second, with a multi-thousand corpus).

My solution up to now was to have another corpus directory, but it means that I cannot use the base bolero commands, etc.

Instead, here is an idea: what if we replaced `with_iterations` with `with_test_time`? What's important for the user is the time taken by the test anyway, considering that the tests are random anyway. And computers can have vastly different speeds.

In addition, doing things this way allows setting a reasonable default test duration (1s) that's independent of how slow the tests themselves are, and that test duration will stop the tests even if they're still in the process of going through the corpus.

WDYT? :)