### PR TITLE
use a not-cryptographic rng for input generator

### DIFF
--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../../README.md"
 rust-version = "1.57.0"
 
 [features]
-rng = ["rand", "bolero-generator/alloc"]
+rng = ["rand", "rand_xoshiro", "bolero-generator/alloc"]
 
 [dependencies]
 anyhow = "1"
@@ -20,6 +20,7 @@ bolero-generator = { version = "0.10", path = "../bolero-generator", default-fea
 lazy_static = "1"
 pretty-hex = "0.3"
 rand = { version = "0.8", optional = true }
+rand_xoshiro = { version = "0.6", optional = true }
 
 [target.'cfg(not(kani))'.dependencies]
 backtrace = { version = "0.3", default-features = false, features = ["std"] }
@@ -27,3 +28,4 @@ backtrace = { version = "0.3", default-features = false, features = ["std"] }
 [dev-dependencies]
 bolero-generator = { path = "../bolero-generator", features = ["std"] }
 rand = "^0.8"
+rand_xoshiro = "0.6"

--- a/lib/bolero-engine/src/rng.rs
+++ b/lib/bolero-engine/src/rng.rs
@@ -1,7 +1,9 @@
 use crate::{driver, panic, ByteSliceTestInput, Engine, TargetLocation, Test};
 use core::{fmt::Debug, time::Duration};
-use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+use rand::{Rng, RngCore, SeedableRng};
 use std::time::Instant;
+
+pub use rand_xoshiro::Xoshiro256PlusPlus as Recommended;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Options {
@@ -170,7 +172,7 @@ where
 }
 
 struct RngState {
-    rng: StdRng,
+    rng: Recommended,
     max_len: usize,
     options: driver::Options,
     buffer: Vec<u8>,
@@ -179,7 +181,7 @@ struct RngState {
 impl RngState {
     fn new(seed: u64, max_len: usize, options: driver::Options) -> Self {
         Self {
-            rng: StdRng::seed_from_u64(seed),
+            rng: SeedableRng::seed_from_u64(seed),
             max_len,
             options,
             buffer: vec![],

--- a/lib/bolero/src/test/input.rs
+++ b/lib/bolero/src/test/input.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(fuzzing_random, allow(dead_code))]
 
-use bolero_engine::RngInput;
+use bolero_engine::{rng::Recommended as Rng, RngInput};
 use bolero_generator::{driver, TypeGenerator};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::SeedableRng;
 use std::{io::Read, path::PathBuf};
 
 pub enum TestInput {
@@ -42,8 +42,8 @@ impl RngTest {
         &self,
         buffer: &'a mut Vec<u8>,
         options: &'a driver::Options,
-    ) -> RngInput<'a, StdRng> {
-        RngInput::new(StdRng::seed_from_u64(self.seed), buffer, options)
+    ) -> RngInput<'a, Rng> {
+        RngInput::new(Rng::seed_from_u64(self.seed), buffer, options)
     }
 
     pub fn buffered_input<'a>(
@@ -51,7 +51,7 @@ impl RngTest {
         buffer: &'a mut Vec<u8>,
         options: &'a driver::Options,
     ) -> RngBufferedInput<'a> {
-        let rng = StdRng::seed_from_u64(self.seed);
+        let rng = Rng::seed_from_u64(self.seed);
         let driver = RngBufferedDriver { rng, buffer };
         let driver = driver::Rng::new(driver, options);
         RngBufferedInput {
@@ -62,7 +62,7 @@ impl RngTest {
 }
 
 pub struct RngBufferedDriver<'a> {
-    rng: StdRng,
+    rng: Rng,
     buffer: &'a mut Vec<u8>,
 }
 

--- a/lib/bolero/src/test/mod.rs
+++ b/lib/bolero/src/test/mod.rs
@@ -84,6 +84,7 @@ impl TestEngine {
         let iterations = self.rng_cfg.iterations_or_default();
         let max_len = self.rng_cfg.max_len_or_default();
         let seed = self.rng_cfg.seed_or_rand();
+        // use StdRng for high entropy seeds
         let mut seed_rng = StdRng::seed_from_u64(seed);
 
         (0..iterations)


### PR DESCRIPTION
We're currently using the `StdRng` for the random engine. Under the hood, this is chacha12, which is overkill for purposes of generating random inputs. This change switches the RNG implementation to use [Xoshiro256PlusPlus](https://docs.rs/rand_xoshiro/latest/rand_xoshiro/struct.Xoshiro256PlusPlus.html), which is covered in [the rand guide](https://rust-random.github.io/book/guide-rngs.html) to have a good tradeoff of speed and quality.

Additionally, I simplified the `bolero_generator::uniform::Uniform` trait implementations a bit, which should hopefully result in better coverage. Before we were branching on if we were in direct mode or not. In practice, coverage-based fuzzing engines spend a lot of time generating inputs rather than executing the tests and direct mode makes that even worse. As such, the uniform impls now always ignore the mode and behave as if forced. In various testing, this improves testing throughput rates.