### PR TITLE
avoid DriverMode branching on byte driver

### DIFF
--- a/bin/cargo-bolero/src/libfuzzer.rs
+++ b/bin/cargo-bolero/src/libfuzzer.rs
@@ -89,6 +89,11 @@ pub(crate) fn reduce(selection: &Selection, reduce: &reduce::Args) -> Result<()>
 
     let inputs = write_control_file(&mut control_file, &corpus_dir)?;
 
+    // no point in shrinking an empty corpus
+    if inputs.is_empty() {
+        return Ok(());
+    }
+
     let mut cmd = test_target.command();
 
     let mut args = vec![


### PR DESCRIPTION
In practice, branching on DriverMode being Forced/Direct in the byte slice driver doesn't result in any better signals to the fuzzing engines. This change makes the previous Forced behavior the default where zeroes are filled in at the end of the input on byte exhaustion.