### PR TITLE
add structural methods to driver

### DIFF
--- a/lib/bolero-generator/src/array.rs
+++ b/lib/bolero-generator/src/array.rs
@@ -2,23 +2,27 @@ use crate::{Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, 
 
 impl<T: TypeGenerator, const LEN: usize> TypeGenerator for [T; LEN] {
     fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-        // TODO use core::array::try_from_fn once stable
-        //      see: https://github.com/rust-lang/rust/issues/89379
-        //      see: https://github.com/camshaft/bolero/issues/133
-        let mut maybe_init: [Option<T>; LEN] = [(); LEN].map(|_| None);
+        driver.enter_product::<Self, _, _>(|driver| {
+            // TODO use core::array::try_from_fn once stable
+            //      see: https://github.com/rust-lang/rust/issues/89379
+            //      see: https://github.com/camshaft/bolero/issues/133
+            let mut maybe_init: [Option<T>; LEN] = [(); LEN].map(|_| None);
 
-        for value in &mut maybe_init {
-            *value = Some(T::generate(driver)?);
-        }
+            for value in &mut maybe_init {
+                *value = Some(T::generate(driver)?);
+            }
 
-        Some(maybe_init.map(|t| t.unwrap()))
+            Some(maybe_init.map(|t| t.unwrap()))
+        })
     }
 
     fn mutate<D: Driver>(&mut self, driver: &mut D) -> Option<()> {
-        for item in self {
-            item.mutate(driver)?;
-        }
-        Some(())
+        driver.enter_product::<Self, _, _>(|driver| {
+            for item in self.iter_mut() {
+                item.mutate(driver)?;
+            }
+            Some(())
+        })
     }
 }
 
@@ -26,23 +30,27 @@ impl<G: ValueGenerator, const LEN: usize> ValueGenerator for [G; LEN] {
     type Output = [G::Output; LEN];
 
     fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-        // TODO use core::array::try_from_fn once stable
-        //      see: https://github.com/rust-lang/rust/issues/89379
-        //      see: https://github.com/camshaft/bolero/issues/133
-        let mut maybe_init: [Option<G::Output>; LEN] = [(); LEN].map(|_| None);
+        driver.enter_product::<Self::Output, _, _>(|driver| {
+            // TODO use core::array::try_from_fn once stable
+            //      see: https://github.com/rust-lang/rust/issues/89379
+            //      see: https://github.com/camshaft/bolero/issues/133
+            let mut maybe_init: [Option<G::Output>; LEN] = [(); LEN].map(|_| None);
 
-        for (generator, value) in self.iter().zip(&mut maybe_init) {
-            *value = Some(generator.generate(driver)?);
-        }
+            for (generator, value) in self.iter().zip(&mut maybe_init) {
+                *value = Some(generator.generate(driver)?);
+            }
 
-        Some(maybe_init.map(|t| t.unwrap()))
+            Some(maybe_init.map(|t| t.unwrap()))
+        })
     }
 
     fn mutate<D: Driver>(&self, driver: &mut D, value: &mut Self::Output) -> Option<()> {
-        for (generator, value) in self.iter().zip(value) {
-            generator.mutate(driver, value)?;
-        }
-        Some(())
+        driver.enter_product::<Self::Output, _, _>(|driver| {
+            for (generator, value) in self.iter().zip(value.iter_mut()) {
+                generator.mutate(driver, value)?;
+            }
+            Some(())
+        })
     }
 }
 

--- a/lib/bolero-generator/src/bounded.rs
+++ b/lib/bolero-generator/src/bounded.rs
@@ -27,7 +27,7 @@ impl<T> BoundExt<T> for Bound<T> {
     }
 }
 
-pub trait BoundedValue<B = Self>: Sized {
+pub trait BoundedValue<B = Self>: 'static + Sized {
     fn gen_bounded<D: Driver>(driver: &mut D, min: Bound<&B>, max: Bound<&B>) -> Option<Self>;
 
     fn mutate_bounded<D: Driver>(

--- a/lib/bolero-generator/src/lib.rs
+++ b/lib/bolero-generator/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::arbitrary::gen_arbitrary;
 pub use crate::driver::Driver;
 
 /// Generate a value for a given type
-pub trait TypeGenerator: Sized {
+pub trait TypeGenerator: 'static + Sized {
     /// Generates a value with the given driver
     fn generate<D: Driver>(driver: &mut D) -> Option<Self>;
 
@@ -82,7 +82,7 @@ pub trait TypeGenerator: Sized {
 
 /// Generate a value with a parameterized generator
 pub trait ValueGenerator: Sized {
-    type Output;
+    type Output: 'static;
 
     /// Generates a value with the given driver
     fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output>;
@@ -229,7 +229,7 @@ pub fn gen_with<T: TypeGeneratorWithParams>() -> T::Output {
 
 pub use one_of::{one_of, one_value_of};
 
-impl<T> ValueGenerator for PhantomData<T> {
+impl<T: 'static> ValueGenerator for PhantomData<T> {
     type Output = Self;
 
     fn generate<D: Driver>(&self, _driver: &mut D) -> Option<Self::Output> {
@@ -237,7 +237,7 @@ impl<T> ValueGenerator for PhantomData<T> {
     }
 }
 
-impl<T> TypeGenerator for PhantomData<T> {
+impl<T: 'static> TypeGenerator for PhantomData<T> {
     fn generate<D: Driver>(_driver: &mut D) -> Option<Self> {
         Some(PhantomData)
     }
@@ -247,7 +247,7 @@ pub struct Constant<T> {
     value: T,
 }
 
-impl<T: Clone> ValueGenerator for Constant<T> {
+impl<T: 'static + Clone> ValueGenerator for Constant<T> {
     type Output = T;
 
     fn generate<D: Driver>(&self, _driver: &mut D) -> Option<Self::Output> {

--- a/lib/bolero-generator/src/num.rs
+++ b/lib/bolero-generator/src/num.rs
@@ -5,7 +5,7 @@ use crate::{
 use core::ops::{Bound, RangeFrom, RangeFull};
 
 macro_rules! impl_integer {
-    ($ty:ident, $call:ident) => {
+    ($ty:ident, $call:ident, $constant:ident) => {
         impl TypeGenerator for $ty {
             fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
                 driver.$call(Bound::Unbounded, Bound::Unbounded)
@@ -15,8 +15,8 @@ macro_rules! impl_integer {
         impl ValueGenerator for $ty {
             type Output = $ty;
 
-            fn generate<D: Driver>(&self, _driver: &mut D) -> Option<Self> {
-                Some(*self)
+            fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self> {
+                driver.$constant(*self)
             }
         }
 
@@ -40,21 +40,37 @@ macro_rules! impl_integer {
     };
 }
 
-impl_integer!(u8, gen_u8);
-impl_integer!(i8, gen_i8);
-impl_integer!(u16, gen_u16);
-impl_integer!(i16, gen_i16);
-impl_integer!(u32, gen_u32);
-impl_integer!(i32, gen_i32);
-impl_integer!(u64, gen_u64);
-impl_integer!(i64, gen_i64);
-impl_integer!(u128, gen_u128);
-impl_integer!(i128, gen_i128);
-impl_integer!(usize, gen_usize);
-impl_integer!(isize, gen_isize);
+impl_integer!(u8, gen_u8, gen_u8_constant);
+impl_integer!(i8, gen_i8, gen_i8_constant);
+impl_integer!(u16, gen_u16, gen_u16_constant);
+impl_integer!(i16, gen_i16, gen_i16_constant);
+impl_integer!(u32, gen_u32, gen_u32_constant);
+impl_integer!(i32, gen_i32, gen_i32_constant);
+impl_integer!(u64, gen_u64, gen_u64_constant);
+impl_integer!(i64, gen_i64, gen_i64_constant);
+impl_integer!(u128, gen_u128, gen_u128_constant);
+impl_integer!(i128, gen_i128, gen_i128_constant);
+impl_integer!(usize, gen_usize, gen_usize_constant);
+impl_integer!(isize, gen_isize, gen_isize_constant);
+
+#[test]
+fn integer_test() {
+    let _ = generator_test!(gen::<u8>());
+    let _ = generator_test!(gen::<i8>());
+    let _ = generator_test!(gen::<u16>());
+    let _ = generator_test!(gen::<i16>());
+    let _ = generator_test!(gen::<u32>());
+    let _ = generator_test!(gen::<i32>());
+    let _ = generator_test!(gen::<u64>());
+    let _ = generator_test!(gen::<i64>());
+    let _ = generator_test!(gen::<u128>());
+    let _ = generator_test!(gen::<i128>());
+    let _ = generator_test!(gen::<usize>());
+    let _ = generator_test!(gen::<isize>());
+}
 
 macro_rules! impl_float {
-    ($ty:ident, $call:ident) => {
+    ($ty:ident, $call:ident, $constant:ident) => {
         impl TypeGenerator for $ty {
             fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
                 driver.$call(Bound::Unbounded, Bound::Unbounded)
@@ -64,8 +80,8 @@ macro_rules! impl_float {
         impl ValueGenerator for $ty {
             type Output = $ty;
 
-            fn generate<D: Driver>(&self, _driver: &mut D) -> Option<Self> {
-                Some(*self)
+            fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self> {
+                driver.$constant(*self)
             }
         }
 
@@ -89,8 +105,15 @@ macro_rules! impl_float {
     };
 }
 
-impl_float!(f32, gen_f32);
-impl_float!(f64, gen_f64);
+impl_float!(f32, gen_f32, gen_f32_constant);
+impl_float!(f64, gen_f64, gen_f64_constant);
+
+#[test]
+fn float_test() {
+    // TODO filter NaN for mutation comparison
+    //let _ = generator_test!(gen::<f32>());
+    //let _ = generator_test!(gen::<f64>());
+}
 
 macro_rules! impl_non_zero_integer {
     ($ty:ident, $inner:ty) => {

--- a/lib/bolero-generator/src/range.rs
+++ b/lib/bolero-generator/src/range.rs
@@ -57,21 +57,26 @@ macro_rules! range_generator {
         where
             Start: ValueGenerator<Output = T>,
             End: ValueGenerator<Output = T>,
+            T: 'static,
         {
             type Output = core::ops::$ty<T>;
 
             fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-                let $start = self.start.generate(driver)?;
-                let $end = self.end.generate(driver)?;
-                Some($new)
+                driver.enter_product::<Self::Output, _, _>(|driver| {
+                    let $start = self.start.generate(driver)?;
+                    let $end = self.end.generate(driver)?;
+                    Some($new)
+                })
             }
         }
 
         impl<T: TypeGenerator> TypeGenerator for core::ops::$ty<T> {
             fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-                let $start = driver.gen()?;
-                let $end = driver.gen()?;
-                Some($new)
+                driver.enter_product::<Self, _, _>(|driver| {
+                    let $start = driver.gen()?;
+                    let $end = driver.gen()?;
+                    Some($new)
+                })
             }
         }
 

--- a/lib/bolero-generator/src/result.rs
+++ b/lib/bolero-generator/src/result.rs
@@ -15,129 +15,105 @@ macro_rules! impl_either {
         $map_b:ident
     ) => {
         #[derive(Debug, Clone)]
-        pub struct $generator<$A, $B, Selector> {
+        pub struct $generator<$A, $B> {
             a: $A,
             b: $B,
-            selector: Selector,
         }
 
-        impl<$A: ValueGenerator, $B: ValueGenerator, Selector: ValueGenerator<Output = bool>>
-            $generator<$A, $B, Selector>
-        {
+        impl<$A: ValueGenerator, $B: ValueGenerator> $generator<$A, $B> {
             pub fn $with_a<Gen: ValueGenerator<Output = $A::Output>>(
                 self,
                 gen: Gen,
-            ) -> $generator<Gen, $B, Selector> {
-                $generator {
-                    a: gen,
-                    b: self.b,
-                    selector: self.selector,
-                }
+            ) -> $generator<Gen, $B> {
+                $generator { a: gen, b: self.b }
             }
 
             pub fn $map_a<Gen: ValueGenerator<Output = $A::Output>, F: Fn($A) -> Gen>(
                 self,
                 map: F,
-            ) -> $generator<Gen, $B, Selector> {
+            ) -> $generator<Gen, $B> {
                 $generator {
                     a: map(self.a),
                     b: self.b,
-                    selector: self.selector,
                 }
             }
 
             pub fn $with_b<Gen: ValueGenerator<Output = $B::Output>>(
                 self,
                 gen: Gen,
-            ) -> $generator<$A, Gen, Selector> {
-                $generator {
-                    a: self.a,
-                    b: gen,
-                    selector: self.selector,
-                }
+            ) -> $generator<$A, Gen> {
+                $generator { a: self.a, b: gen }
             }
 
             pub fn $map_b<Gen: ValueGenerator<Output = $B::Output>, F: Fn($B) -> Gen>(
                 self,
                 map: F,
-            ) -> $generator<$A, Gen, Selector> {
+            ) -> $generator<$A, Gen> {
                 $generator {
                     a: self.a,
                     b: map(self.b),
-                    selector: self.selector,
-                }
-            }
-
-            pub fn with_selector<Gen: ValueGenerator<Output = bool>>(
-                self,
-                selector: Gen,
-            ) -> $generator<$A, $B, Gen> {
-                $generator {
-                    a: self.a,
-                    b: self.b,
-                    selector,
-                }
-            }
-
-            pub fn map_selector<Gen: ValueGenerator<Output = bool>, F: Fn(Selector) -> Gen>(
-                self,
-                map: F,
-            ) -> $generator<$A, $B, Gen> {
-                $generator {
-                    a: self.a,
-                    b: self.b,
-                    selector: map(self.selector),
                 }
             }
         }
 
-        impl<$A: ValueGenerator, $B: ValueGenerator, Selector: ValueGenerator<Output = bool>>
-            ValueGenerator for $generator<$A, $B, Selector>
-        {
+        impl<$A: ValueGenerator, $B: ValueGenerator> ValueGenerator for $generator<$A, $B> {
             type Output = $ty<$A::Output, $B::Output>;
 
             #[inline]
             fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-                Some(if self.selector.generate(driver)? {
-                    $ty::$A(self.a.generate(driver)?)
-                } else {
-                    $ty::$B(self.b.generate(driver)?)
-                })
+                driver.enter_sum::<Self::Output, _, _>(
+                    Some(&[stringify!($A), stringify!($B)]),
+                    2,
+                    0,
+                    |driver, idx| {
+                        if idx == 0 {
+                            Some($ty::$A(self.a.generate(driver)?))
+                        } else {
+                            Some($ty::$B(self.b.generate(driver)?))
+                        }
+                    },
+                )
             }
 
             #[inline]
             fn mutate<D: Driver>(&self, driver: &mut D, value: &mut Self::Output) -> Option<()> {
-                #[allow(clippy::redundant_pattern_matching)]
-                let prev_selection = match value {
-                    $ty::$A(_) => true,
-                    $ty::$B(_) => false,
-                };
+                driver.enter_sum::<Self::Output, _, _>(
+                    Some(&[stringify!($A), stringify!($B)]),
+                    2,
+                    0,
+                    |driver, new_selection| {
+                        #[allow(clippy::redundant_pattern_matching)]
+                        let prev_selection = match value {
+                            $ty::$A(_) => 0,
+                            $ty::$B(_) => 1,
+                        };
 
-                let mut new_selection = prev_selection;
-                self.selector.mutate(driver, &mut new_selection)?;
-
-                if prev_selection == new_selection {
-                    match value {
-                        $ty::$A(value) => self.a.mutate(driver, value),
-                        $ty::$B(value) => self.b.mutate(driver, value),
-                    }
-                } else {
-                    let next = if new_selection {
-                        $ty::$A(self.a.generate(driver)?)
-                    } else {
-                        $ty::$B(self.b.generate(driver)?)
-                    };
-                    let prev = core::mem::replace(value, next);
-                    self.driver_cache(driver, prev);
-                    Some(())
-                }
+                        if prev_selection == new_selection {
+                            match value {
+                                $ty::$A(value) => self.a.mutate(driver, value),
+                                $ty::$B(value) => self.b.mutate(driver, value),
+                            }
+                        } else {
+                            let next = if new_selection == 0 {
+                                $ty::$A(self.a.generate(driver)?)
+                            } else {
+                                $ty::$B(self.b.generate(driver)?)
+                            };
+                            match core::mem::replace(value, next) {
+                                $ty::$A(v) => self.a.driver_cache(driver, v),
+                                $ty::$B(v) => self.b.driver_cache(driver, v),
+                            }
+                            Some(())
+                        }
+                    },
+                )
             }
 
             #[inline]
             fn driver_cache<D: Driver>(&self, driver: &mut D, value: Self::Output) {
                 match value {
-                    $ty::$A(value) => self.a.driver_cache(driver, value),
-                    $ty::$B(value) => self.b.driver_cache(driver, value),
+                    $ty::$A(v) => self.a.driver_cache(driver, v),
+                    $ty::$B(v) => self.b.driver_cache(driver, v),
                 }
             }
         }
@@ -160,17 +136,12 @@ macro_rules! impl_either {
         }
 
         impl<$A: TypeGenerator, $B: TypeGenerator> TypeGeneratorWithParams for $ty<$A, $B> {
-            type Output = $generator<
-                TypeValueGenerator<$A>,
-                TypeValueGenerator<$B>,
-                TypeValueGenerator<bool>,
-            >;
+            type Output = $generator<TypeValueGenerator<$A>, TypeValueGenerator<$B>>;
 
             fn gen_with() -> Self::Output {
                 $generator {
                     a: Default::default(),
                     b: Default::default(),
-                    selector: Default::default(),
                 }
             }
         }
@@ -191,96 +162,69 @@ impl_either!(
     map_right
 );
 
-pub struct OptionGenerator<V, Selector> {
+pub struct OptionGenerator<V> {
     value: V,
-    selector: Selector,
 }
 
-impl<V: ValueGenerator, Selector: ValueGenerator<Output = bool>> OptionGenerator<V, Selector> {
+impl<V: ValueGenerator> OptionGenerator<V> {
     pub fn value<Gen: ValueGenerator<Output = V::Output>>(
         self,
         value: Gen,
-    ) -> OptionGenerator<Gen, Selector> {
-        OptionGenerator {
-            value,
-            selector: self.selector,
-        }
+    ) -> OptionGenerator<Gen> {
+        OptionGenerator { value }
     }
 
     pub fn map_value<Gen: ValueGenerator<Output = V::Output>, F: Fn(V) -> Gen>(
         self,
         map: F,
-    ) -> OptionGenerator<Gen, Selector> {
+    ) -> OptionGenerator<Gen> {
         OptionGenerator {
             value: map(self.value),
-            selector: self.selector,
-        }
-    }
-
-    pub fn selector<Gen: ValueGenerator<Output = bool>>(
-        self,
-        selector: Gen,
-    ) -> OptionGenerator<V, Gen> {
-        OptionGenerator {
-            value: self.value,
-            selector,
-        }
-    }
-
-    pub fn map_selector<Gen: ValueGenerator<Output = bool>, F: Fn(Selector) -> Gen>(
-        self,
-        map: F,
-    ) -> OptionGenerator<V, Gen> {
-        OptionGenerator {
-            value: self.value,
-            selector: map(self.selector),
         }
     }
 }
 
-impl<V: ValueGenerator, Selector: ValueGenerator<Output = bool>> ValueGenerator
-    for OptionGenerator<V, Selector>
-{
+impl<V: ValueGenerator> ValueGenerator for OptionGenerator<V> {
     type Output = Option<V::Output>;
 
     #[inline]
     fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-        Some(if self.selector.generate(driver)? {
-            Some(self.value.generate(driver)?)
-        } else {
-            None
+        driver.enter_sum::<Self::Output, _, _>(Some(&["None", "Some"]), 2, 0, |driver, idx| {
+            if idx == 0 {
+                Some(None)
+            } else {
+                Some(Some(self.value.generate(driver)?))
+            }
         })
     }
 
     #[inline]
     fn mutate<D: Driver>(&self, driver: &mut D, value: &mut Self::Output) -> Option<()> {
-        let prev_selection = value.is_some();
+        driver.enter_sum::<Self::Output, _, _>(
+            Some(&["None", "Some"]),
+            2,
+            0,
+            |driver, new_selection| {
+                let prev_selection = if value.is_some() { 1 } else { 0 };
 
-        let mut new_selection = prev_selection;
-        self.selector.mutate(driver, &mut new_selection)?;
-
-        if prev_selection == new_selection {
-            match value {
-                Some(value) => self.value.mutate(driver, value),
-                None => Some(()),
-            }
-        } else {
-            let next = if new_selection {
-                Some(self.value.generate(driver)?)
-            } else {
-                None
-            };
-            let prev = core::mem::replace(value, next);
-            self.driver_cache(driver, prev);
-            Some(())
-        }
-    }
-
-    #[inline]
-    fn driver_cache<D: Driver>(&self, driver: &mut D, value: Self::Output) {
-        if let Some(value) = value {
-            self.value.driver_cache(driver, value);
-        }
+                if prev_selection == new_selection {
+                    match value {
+                        Some(value) => self.value.mutate(driver, value),
+                        None => Some(()),
+                    }
+                } else {
+                    let next = if new_selection == 1 {
+                        Some(self.value.generate(driver)?)
+                    } else {
+                        None
+                    };
+                    if let Some(prev) = core::mem::replace(value, next) {
+                        self.value.driver_cache(driver, prev);
+                    }
+                    Some(())
+                }
+            },
+        )
     }
 }
 
@@ -302,12 +246,11 @@ impl<V: TypeGenerator> TypeGenerator for Option<V> {
 }
 
 impl<V: TypeGenerator> TypeGeneratorWithParams for Option<V> {
-    type Output = OptionGenerator<TypeValueGenerator<V>, TypeValueGenerator<bool>>;
+    type Output = OptionGenerator<TypeValueGenerator<V>>;
 
     fn gen_with() -> Self::Output {
         OptionGenerator {
             value: Default::default(),
-            selector: Default::default(),
         }
     }
 }

--- a/lib/bolero-generator/src/time.rs
+++ b/lib/bolero-generator/src/time.rs
@@ -1,4 +1,7 @@
-use crate::{Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, ValueGenerator};
+use crate::{
+    bounded::{BoundExt, BoundedValue},
+    Driver, TypeGenerator, TypeGeneratorWithParams, TypeValueGenerator, ValueGenerator,
+};
 use core::{ops::Range, time::Duration};
 
 pub struct DurationGenerator<Seconds, Nanos> {
@@ -62,18 +65,22 @@ where
     type Output = Duration;
 
     fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-        let seconds = self.seconds.generate(driver)?;
-        let nanos = self.nanos.generate(driver)?;
-        Some(Duration::new(seconds, nanos))
+        driver.enter_product::<Duration, _, _>(|driver| {
+            let seconds = self.seconds.generate(driver);
+            let nanos = self.nanos.generate(driver);
+            Some(Duration::new(seconds?, nanos?))
+        })
     }
 
     fn mutate<D: Driver>(&self, driver: &mut D, value: &mut Duration) -> Option<()> {
-        let mut seconds = value.as_secs();
-        self.seconds.mutate(driver, &mut seconds)?;
-        let mut nanos = value.subsec_nanos();
-        self.nanos.mutate(driver, &mut nanos)?;
-        *value = Duration::new(seconds, nanos);
-        Some(())
+        driver.enter_product::<Duration, _, _>(|driver| {
+            let mut seconds = value.as_secs();
+            self.seconds.mutate(driver, &mut seconds)?;
+            let mut nanos = value.subsec_nanos();
+            self.nanos.mutate(driver, &mut nanos)?;
+            *value = Duration::new(seconds, nanos);
+            Some(())
+        })
     }
 }
 
@@ -96,4 +103,25 @@ impl TypeGeneratorWithParams for Duration {
             nanos: VALID_NANOS_RANGE,
         }
     }
+}
+
+impl BoundedValue for Duration {
+    #[inline]
+    fn gen_bounded<D: Driver>(
+        driver: &mut D,
+        min: core::ops::Bound<&Self>,
+        max: core::ops::Bound<&Self>,
+    ) -> Option<Self> {
+        let min = BoundExt::map(min, |min| min.as_nanos());
+        let max = BoundExt::map(max, |max| max.as_nanos());
+        let value = u128::gen_bounded(driver, BoundExt::as_ref(&min), BoundExt::as_ref(&max))?;
+        let value = value.try_into().ok()?;
+        let value = Duration::from_nanos(value);
+        Some(value)
+    }
+}
+
+#[test]
+fn duration_test() {
+    let _ = generator_test!(gen::<Duration>());
 }

--- a/lib/bolero-generator/tests/derive_test.rs
+++ b/lib/bolero-generator/tests/derive_test.rs
@@ -52,6 +52,27 @@ pub enum Expr {
 }
 
 #[derive(Debug, Clone, TypeGenerator, PartialEq)]
+pub enum Animal {
+    Dog { color: Color, tail: Tail },
+    Bear { color: Color },
+    Cat { color: Color, tail: Tail },
+}
+
+#[derive(Debug, Clone, TypeGenerator, PartialEq)]
+pub enum Color {
+    Brown,
+    Black,
+    White,
+}
+
+#[derive(Debug, Clone, TypeGenerator, PartialEq)]
+pub enum Tail {
+    Short,
+    Medium,
+    Long,
+}
+
+#[derive(Debug, Clone, TypeGenerator, PartialEq)]
 pub enum GenericTypes<T1, T2> {
     T1Value(T1),
     T2Value(T2),
@@ -95,11 +116,16 @@ fn derive_enum_test() {
 }
 
 #[test]
+fn derive_animal_test() {
+    let _ = generator_test!(Animal::gen());
+}
+
+#[test]
 fn derive_union_test() {
     let _ = generator_no_clone_test!(Union::gen());
 }
 
 #[test]
-fn derive_recursive_test() {
+fn derive_expr_test() {
     let _ = generator_test!(Expr::gen());
 }


### PR DESCRIPTION
This functionality extends the driver interface to allow generators to provide insights into the structure of the types being generated. This will be used to implement #203.