### PR TITLE
add more inlines for better optimization

### DIFF
--- a/examples/boolean-tree/src/lib.rs
+++ b/examples/boolean-tree/src/lib.rs
@@ -1,4 +1,5 @@
 use bolero_generator::TypeGenerator;
+use core::fmt;
 
 thread_local! {
     static SHOULD_PANIC: bool = {
@@ -13,24 +14,55 @@ thread_local! {
 #[cfg(test)]
 mod tests;
 
+#[derive(Copy, Clone)]
+pub struct Shape<'a>(&'a Expr);
+
+impl<'a> fmt::Debug for Shape<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Expr::Value(_) => write!(f, "Value"),
+            Expr::And(a, b) => f
+                .debug_tuple("And")
+                .field(&Shape(a))
+                .field(&Shape(b))
+                .finish(),
+            Expr::Or(a, b) => f
+                .debug_tuple("Or")
+                .field(&Shape(a))
+                .field(&Shape(b))
+                .finish(),
+            Expr::Xor(a, b) => f
+                .debug_tuple("Xor")
+                .field(&Shape(a))
+                .field(&Shape(b))
+                .finish(),
+            Expr::Not(a) => f.debug_tuple("Not").field(&Shape(a)).finish(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, TypeGenerator)]
 pub enum Expr {
     Value(bool),
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
     Xor(Box<Expr>, Box<Expr>),
-    Nand(Box<Expr>, Box<Expr>),
     Not(Box<Expr>),
 }
 
 impl Expr {
+    #[inline]
+    pub fn shape(&self) -> Shape {
+        Shape(self)
+    }
+
+    #[inline]
     pub fn eval(&self) -> bool {
         match self {
             Expr::Value(value) => *value,
             Expr::And(a, b) => a.eval() && b.eval(),
             Expr::Or(a, b) => a.eval() || b.eval(),
             Expr::Xor(a, b) => a.eval() ^ b.eval(),
-            Expr::Nand(a, b) => !(a.eval() && b.eval()),
             Expr::Not(_) if SHOULD_PANIC.with(|v| *v) => unreachable!(),
             Expr::Not(a) => !a.eval(),
         }

--- a/lib/bolero-engine/src/noop/panic.rs
+++ b/lib/bolero-engine/src/noop/panic.rs
@@ -30,30 +30,39 @@ impl PanicError {
     }
 }
 
-pub fn catch<F: RefUnwindSafe + FnOnce() -> Output, Output>(fun: F) -> Result<Output, PanicError> {
-    Ok(fun())
+#[inline(always)]
+pub fn catch<F: RefUnwindSafe + FnOnce() -> Result<Output, PanicError>, Output>(
+    fun: F,
+) -> Result<Output, PanicError> {
+    fun()
 }
 
+#[inline(always)]
 pub fn take_panic() -> Option<PanicError> {
     None
 }
 
+#[inline(always)]
 pub fn capture_backtrace(_value: bool) -> bool {
     false
 }
 
+#[inline(always)]
 pub fn forward_panic(_value: bool) -> bool {
     false
 }
 
+#[inline(always)]
 pub fn set_hook() {
     // no-op
 }
 
+#[inline(always)]
 pub fn rust_backtrace() -> bool {
     false
 }
 
+#[inline(always)]
 pub fn thread_name() -> String {
     String::from("main")
 }

--- a/lib/bolero-engine/src/test.rs
+++ b/lib/bolero-engine/src/test.rs
@@ -37,6 +37,7 @@ where
 {
     type Value = SliceDebug<Vec<u8>>;
 
+    #[inline]
     fn test<T: Input<Result<bool, PanicError>>>(
         &mut self,
         input: &mut T,
@@ -48,10 +49,11 @@ where
                     Ok(()) => Ok(true),
                     Err(err) => Err(err),
                 }
-            })?
+            })
         })
     }
 
+    #[inline]
     fn generate_value<T: Input<Self::Value>>(&self, input: &mut T) -> Self::Value {
         input.with_slice(&mut |slice| SliceDebug(slice.to_vec()))
     }
@@ -73,6 +75,7 @@ where
 {
     type Value = SliceDebug<Vec<u8>>;
 
+    #[inline]
     fn test<T: Input<Result<bool, PanicError>>>(
         &mut self,
         input: &mut T,
@@ -84,10 +87,11 @@ where
                     Ok(()) => Ok(true),
                     Err(err) => Err(err),
                 }
-            })?
+            })
         })
     }
 
+    #[inline]
     fn generate_value<T: Input<Self::Value>>(&self, input: &mut T) -> Self::Value {
         input.with_slice(&mut |slice| SliceDebug(slice.to_vec()))
     }
@@ -109,6 +113,7 @@ where
 {
     type Value = SliceDebug<Vec<u8>>;
 
+    #[inline]
     fn test<T: Input<Result<bool, PanicError>>>(
         &mut self,
         input: &mut T,
@@ -121,10 +126,11 @@ where
                     Ok(()) => Ok(true),
                     Err(err) => Err(err),
                 }
-            })?
+            })
         })
     }
 
+    #[inline]
     fn generate_value<T: Input<Self::Value>>(&self, input: &mut T) -> Self::Value {
         input.with_slice(&mut |slice| SliceDebug(slice.to_vec()))
     }
@@ -186,6 +192,7 @@ where
 {
     type Value = G::Output;
 
+    #[inline]
     fn test<T: Input<Result<bool, PanicError>>>(
         &mut self,
         input: &mut T,
@@ -202,10 +209,11 @@ where
                     Ok(()) => Ok(true),
                     Err(err) => Err(err),
                 }
-            })?
+            })
         })
     }
 
+    #[inline]
     fn generate_value<T: Input<Self::Value>>(&self, input: &mut T) -> Self::Value {
         input.with_driver(&mut |driver| {
             let forward_panic = crate::panic::forward_panic(true);
@@ -240,6 +248,7 @@ where
 {
     type Value = G::Output;
 
+    #[inline]
     fn test<T: Input<Result<bool, PanicError>>>(
         &mut self,
         input: &mut T,
@@ -268,10 +277,11 @@ where
                     Ok(()) => Ok(true),
                     Err(err) => Err(err),
                 }
-            })?
+            })
         })
     }
 
+    #[inline]
     fn generate_value<T: Input<Self::Value>>(&self, input: &mut T) -> Self::Value {
         input.with_driver(&mut |driver| {
             let forward_panic = crate::panic::forward_panic(true);

--- a/lib/bolero-generator/src/driver/macros.rs
+++ b/lib/bolero-generator/src/driver/macros.rs
@@ -1,6 +1,6 @@
 macro_rules! gen_int {
     ($name:ident, $ty:ident) => {
-        #[inline]
+        #[inline(always)]
         fn $name(&mut self, min: Bound<&$ty>, max: Bound<&$ty>) -> Option<$ty> {
             Uniform::sample(self, min, max)
         }
@@ -74,12 +74,12 @@ macro_rules! gen_from_bytes {
 
         gen_float!(gen_f64, f64);
 
-        #[inline]
+        #[inline(always)]
         fn gen_char(&mut self, min: Bound<&char>, max: Bound<&char>) -> Option<char> {
             char::sample(self, min, max)
         }
 
-        #[inline]
+        #[inline(always)]
         fn gen_bool(&mut self, probability: Option<f32>) -> Option<bool> {
             if let Some(probability) = probability {
                 let value = self.sample_u32()? as f32 / core::u32::MAX as f32;
@@ -89,20 +89,13 @@ macro_rules! gen_from_bytes {
             }
         }
 
-        #[inline]
+        #[inline(always)]
         fn gen_variant(&mut self, variants: usize, base_case: usize) -> Option<usize> {
-            match FillBytes::mode(self) {
-                DriverMode::Direct => {
-                    Uniform::sample(self, Bound::Unbounded, Bound::Excluded(&variants))
-                }
-                DriverMode::Forced => {
-                    if self.depth == self.max_depth {
-                        return Some(base_case);
-                    }
-
-                    Uniform::sample(self, Bound::Unbounded, Bound::Excluded(&variants))
-                }
+            if self.depth == self.max_depth {
+                return Some(base_case);
             }
+
+            Uniform::sample(self, Bound::Unbounded, Bound::Excluded(&variants))
         }
     };
 }


### PR DESCRIPTION
in trying to improve iteration speeds i noticed the panic functions showing up a bit. after making these changes, iteration speed has improved slightly:


### boolean-tree example

```
$ cd examples/boolean-tree
$ cargo +nightly bolero test tests::model_test --engine random --sanitizer NONE
```

#### before

```
#3929088	iterations/s: 3929088
#7855104	iterations/s: 3926016
#11784192	iterations/s: 3929088
#15715328	iterations/s: 3931136
#19649536	iterations/s: 3934208
#23584768	iterations/s: 3935232
```

#### after

```
#4470784	iterations/s: 4470784
#8924160	iterations/s: 4453376
#13398016	iterations/s: 4473856
#17874944	iterations/s: 4476928
#22356992	iterations/s: 4482048
#26848256	iterations/s: 4491264
```