### PR TITLE
deprecate driver mode

### DIFF
--- a/lib/bolero-engine/src/lib.rs
+++ b/lib/bolero-engine/src/lib.rs
@@ -1,6 +1,6 @@
 pub use anyhow::Error;
 pub use bolero_generator::{
-    driver::{self, Driver, DriverMode},
+    driver::{self, Driver},
     TypeGenerator, ValueGenerator,
 };
 

--- a/lib/bolero-engine/src/shrink/tests.rs
+++ b/lib/bolero-engine/src/shrink/tests.rs
@@ -6,7 +6,7 @@ macro_rules! shrink_test {
         #[test]
         fn $name() {
             #[allow(unused_imports)]
-            use bolero_generator::{driver::DriverMode, gen, ValueGenerator};
+            use bolero_generator::{gen, ValueGenerator};
 
             panic::forward_panic(true);
             panic::capture_backtrace(true);
@@ -14,9 +14,7 @@ macro_rules! shrink_test {
             let mut test = crate::ClonedGeneratorTest::new($check, $gen);
             let input = ($input).to_vec();
 
-            let options = driver::Options::default()
-                .with_driver_mode(DriverMode::Forced)
-                .with_shrink_time(Duration::from_secs(1));
+            let options = driver::Options::default().with_shrink_time(Duration::from_secs(1));
 
             let failure = Shrinker::new(&mut test, input, None, &options)
                 .shrink()

--- a/lib/bolero-generator/src/arbitrary.rs
+++ b/lib/bolero-generator/src/arbitrary.rs
@@ -82,20 +82,20 @@ mod tests {
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
-    struct UnlikelyToBeValid(u128);
+    struct RandomlyValid(bool);
 
-    impl<'a> arbitrary::Arbitrary<'a> for UnlikelyToBeValid {
-        fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<UnlikelyToBeValid> {
-            let v = u.arbitrary::<u128>()?;
-            if v >= 1024 {
+    impl<'a> arbitrary::Arbitrary<'a> for RandomlyValid {
+        fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+            let v: bool = u.arbitrary()?;
+            if !v {
                 return Err(arbitrary::Error::IncorrectFormat);
             }
-            Ok(UnlikelyToBeValid(v))
+            Ok(Self(v))
         }
     }
 
     #[test]
-    fn unlikely_to_be_valid() {
-        let _ = generator_test!(gen_arbitrary::<UnlikelyToBeValid>());
+    fn randomly_valid() {
+        let _ = generator_test!(gen_arbitrary::<RandomlyValid>());
     }
 }

--- a/lib/bolero-generator/src/driver.rs
+++ b/lib/bolero-generator/src/driver.rs
@@ -163,6 +163,7 @@ pub trait Driver: Sized {
 
 /// Byte exhaustion strategy for the driver
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[deprecated = "Driver mode should no longer used by generator implementations"]
 pub enum DriverMode {
     /// When the driver bytes are exhausted, the driver will fail fill input bytes.
     /// This is useful for fuzz engines that want accurate mapping of inputs to coverage.
@@ -175,7 +176,6 @@ pub enum DriverMode {
 
 #[derive(Clone, Debug, Default)]
 pub struct Options {
-    driver_mode: Option<DriverMode>,
     shrink_time: Option<core::time::Duration>,
     max_depth: Option<usize>,
     max_len: Option<usize>,
@@ -185,11 +185,6 @@ impl Options {
     pub const DEFAULT_MAX_DEPTH: usize = 5;
     pub const DEFAULT_MAX_LEN: usize = 4096;
     pub const DEFAULT_SHRINK_TIME: core::time::Duration = core::time::Duration::from_secs(1);
-
-    pub fn with_driver_mode(mut self, driver_mode: DriverMode) -> Self {
-        self.driver_mode = Some(driver_mode);
-        self
-    }
 
     pub fn with_shrink_time(mut self, shrink_time: core::time::Duration) -> Self {
         self.shrink_time = Some(shrink_time);
@@ -203,11 +198,6 @@ impl Options {
 
     pub fn with_max_len(mut self, max_len: usize) -> Self {
         self.max_len = Some(max_len);
-        self
-    }
-
-    pub fn set_driver_mode(&mut self, driver_mode: DriverMode) -> &mut Self {
-        self.driver_mode = Some(driver_mode);
         self
     }
 
@@ -242,11 +232,6 @@ impl Options {
     }
 
     #[inline]
-    pub fn driver_mode(&self) -> Option<DriverMode> {
-        self.driver_mode
-    }
-
-    #[inline]
     pub fn max_depth_or_default(&self) -> usize {
         self.max_depth.unwrap_or(Self::DEFAULT_MAX_DEPTH)
     }
@@ -271,7 +256,6 @@ impl Options {
             };
         }
 
-        merge!(driver_mode);
         merge!(max_depth);
         merge!(max_len);
         merge!(shrink_time);

--- a/lib/bolero-generator/src/driver/bytes.rs
+++ b/lib/bolero-generator/src/driver/bytes.rs
@@ -2,7 +2,6 @@ use super::*;
 
 #[derive(Debug)]
 pub struct ByteSliceDriver<'a> {
-    mode: DriverMode,
     input: &'a [u8],
     depth: usize,
     max_depth: usize,
@@ -10,14 +9,12 @@ pub struct ByteSliceDriver<'a> {
 
 impl<'a> ByteSliceDriver<'a> {
     pub fn new(input: &'a [u8], options: &Options) -> Self {
-        let mode = options.driver_mode.unwrap_or(DriverMode::Direct);
         let max_depth = options.max_depth_or_default();
         let len = options.max_len_or_default().min(input.len());
         let input = &input[..len];
 
         Self {
             input,
-            mode,
             depth: 0,
             max_depth,
         }
@@ -30,11 +27,6 @@ impl<'a> ByteSliceDriver<'a> {
 }
 
 impl<'a> FillBytes for ByteSliceDriver<'a> {
-    #[inline]
-    fn mode(&self) -> DriverMode {
-        self.mode
-    }
-
     #[inline]
     fn peek_bytes(&mut self, offset: usize, bytes: &mut [u8]) -> Option<()> {
         match self.input.len().checked_sub(offset) {

--- a/lib/bolero-generator/src/driver/macros.rs
+++ b/lib/bolero-generator/src/driver/macros.rs
@@ -19,15 +19,7 @@ macro_rules! gen_float {
                 return Some(<$ty>::from_le_bytes(bytes));
             }
 
-            // if we're in direct mode, just sample a value and check if it's within the provided range
-            if FillBytes::mode(self) == DriverMode::Direct {
-                return self
-                    .$name(Bound::Unbounded, Bound::Unbounded)
-                    .filter(|value| (min, max).contains(value));
-            }
-
             // TODO make this all less biased
-
             if let Some(value) = self
                 .$name(Bound::Unbounded, Bound::Unbounded)
                 .filter(|value| (min, max).contains(value))

--- a/lib/bolero-generator/src/lib.rs
+++ b/lib/bolero-generator/src/lib.rs
@@ -268,6 +268,9 @@ pub mod prelude {
         TypeGenerator, TypeGeneratorWithParams, ValueGenerator,
     };
 
+    #[allow(deprecated)]
+    pub use crate::driver::DriverMode;
+
     #[cfg(feature = "arbitrary")]
     pub use crate::gen_arbitrary;
 }

--- a/lib/bolero-generator/src/testing.rs
+++ b/lib/bolero-generator/src/testing.rs
@@ -2,12 +2,12 @@
 macro_rules! generator_test {
     ($gen:expr) => {{
         use $crate::{
-            driver::{ByteSliceDriver, DriverMode, Options, Rng},
+            driver::{ByteSliceDriver, Options, Rng},
             *,
         };
         let gen = $gen;
 
-        let options = Options::default().with_driver_mode(DriverMode::Forced);
+        let options = Options::default();
 
         let mut rng_driver = Rng::new(rand::thread_rng(), &options);
 
@@ -19,7 +19,6 @@ macro_rules! generator_test {
             .unwrap();
 
         {
-            let options = options.clone().with_driver_mode(DriverMode::Direct);
             for input in inputs.iter() {
                 if let Some(value) =
                     ValueGenerator::generate(&gen, &mut ByteSliceDriver::new(input, &options))
@@ -39,8 +38,8 @@ macro_rules! generator_test {
             }
         }
 
-        // keep track of failed forced inputs and make sure they didn't all fail
-        let mut failed_forced = 0;
+        // keep track of failed inputs and make sure they didn't all fail
+        let mut failed = 0;
 
         for input in inputs.iter() {
             if let Some(value) =
@@ -58,11 +57,11 @@ macro_rules! generator_test {
                     "a mutation with the same input should produce the original"
                 );
             } else {
-                failed_forced += 1;
+                failed += 1;
             }
         }
 
-        assert_ne!(failed_forced, inputs.len(), "all the forced inputs failed");
+        assert_ne!(failed, inputs.len(), "all the inputs failed");
 
         ValueGenerator::generate(&gen, &mut rng_driver)
     }};
@@ -72,12 +71,12 @@ macro_rules! generator_test {
 macro_rules! generator_no_clone_test {
     ($gen:expr) => {{
         use $crate::{
-            driver::{ByteSliceDriver, DriverMode, Options, Rng},
+            driver::{ByteSliceDriver, Options, Rng},
             *,
         };
         let gen = $gen;
 
-        let options = Options::default().with_driver_mode(DriverMode::Forced);
+        let options = Options::default();
 
         let mut rng_driver = Rng::new(rand::thread_rng(), &options);
 
@@ -89,7 +88,6 @@ macro_rules! generator_no_clone_test {
             .unwrap();
 
         {
-            let options = options.clone().with_driver_mode(DriverMode::Direct);
             for input in inputs.iter() {
                 if let Some(mut value) =
                     ValueGenerator::generate(&gen, &mut ByteSliceDriver::new(input, &options))
@@ -105,7 +103,7 @@ macro_rules! generator_no_clone_test {
         }
 
         // keep track of failed forced inputs and make sure they didn't all fail
-        let mut failed_forced = 0;
+        let mut failed = 0;
 
         for input in inputs.iter() {
             if let Some(mut value) =
@@ -118,11 +116,11 @@ macro_rules! generator_no_clone_test {
                 )
                 .expect("mutation with same driver should produce a value");
             } else {
-                failed_forced += 1;
+                failed += 1;
             }
         }
 
-        assert_ne!(failed_forced, inputs.len(), "all the forced inputs failed");
+        assert_ne!(failed, inputs.len(), "all the inputs failed");
 
         ValueGenerator::generate(&gen, &mut rng_driver)
     }};

--- a/lib/bolero-kani/src/lib.rs
+++ b/lib/bolero-kani/src/lib.rs
@@ -76,7 +76,11 @@ pub mod lib {
 
         fn with_slice<F: FnMut(&[u8]) -> Output>(&mut self, f: &mut F) -> Output {
             // TODO make this configurable
-            const MAX_LEN: usize = 256;
+            const MAX_LEN: usize = driver::Options::DEFAULT_MAX_LEN;
+
+            let bytes = kani::vec::any_vec::<u8, MAX_LEN>();
+            let len = self.options.max_len_or_default().min(MAX_LEN);
+            kani::assume(bytes.len() <= len);
 
             let array: [u8; MAX_LEN] = kani::any();
             let len = kani::any();

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -35,7 +35,7 @@ pub use bolero_generator::prelude::*;
 #[doc(hidden)]
 pub use bolero_engine::{self, TargetLocation, __item_path__};
 
-pub use bolero_engine::{Driver, DriverMode, Engine, Test};
+pub use bolero_engine::{Driver, Engine, Test};
 
 #[cfg(test)]
 mod tests;
@@ -341,8 +341,10 @@ impl<G: generator::ValueGenerator, Engine, InputOwnership> TestTarget<G, Engine,
     }
 
     /// Set the driver mode for the test target
-    pub fn with_driver_mode(mut self, mode: DriverMode) -> Self {
-        self.driver_options.set_driver_mode(mode);
+    #[deprecated = "Driver mode is no longer being used by generator implementations"]
+    #[allow(deprecated)]
+    pub fn with_driver_mode(self, mode: DriverMode) -> Self {
+        let _ = mode;
         self
     }
 

--- a/lib/bolero/src/test/mod.rs
+++ b/lib/bolero/src/test/mod.rs
@@ -204,19 +204,8 @@ impl TestEngine {
         T: Test,
         T::Value: core::fmt::Debug,
     {
-        let mut file_options = options.clone();
-        let mut rng_options = options;
-
-        // set the driver mode to direct for file replays since they were likely generated with
-        // fuzzers
-        if file_options.driver_mode().is_none() {
-            file_options.set_driver_mode(crate::DriverMode::Direct);
-        }
-
-        // set the driver mode to forced so we increase the likelihood of valid generators
-        if rng_options.driver_mode().is_none() {
-            rng_options.set_driver_mode(crate::DriverMode::Forced);
-        }
+        let file_options = options.clone();
+        let rng_options = options;
 
         let file_options = &file_options;
         let rng_options = &rng_options;


### PR DESCRIPTION
Initially, DriverMode was designed to give various drivers options for how to generate values, either in Forced mode, which basically tries everything it can to generate a valid value, or `Direct` mode, which maps the underlying bytes directly to a value and bails if not possible. In practice, DriverMode is confusing, inconsistent, and poorly documented.

This change deprecates the use of `DriverMode` and instead just uses a combination of the two in places where it makes sense. Essentially, the way generators are implemented no longer depend on the driver type itself.