### PR TITLE
revert kani slice size change

### DIFF
--- a/lib/bolero-kani/Cargo.toml
+++ b/lib/bolero-kani/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-kani"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "kani plugin for bolero"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero-kani/src/lib.rs
+++ b/lib/bolero-kani/src/lib.rs
@@ -76,16 +76,13 @@ pub mod lib {
 
         fn with_slice<F: FnMut(&[u8]) -> Output>(&mut self, f: &mut F) -> Output {
             // TODO make this configurable
-            const MAX_LEN: usize = driver::Options::DEFAULT_MAX_LEN;
+            const MAX_LEN: usize = 256;
 
             let bytes = kani::vec::any_vec::<u8, MAX_LEN>();
             let len = self.options.max_len_or_default().min(MAX_LEN);
             kani::assume(bytes.len() <= len);
 
-            let array: [u8; MAX_LEN] = kani::any();
-            let len = kani::any();
-            kani::assume(len <= MAX_LEN);
-            f(&array[..len])
+            f(&bytes)
         }
 
         fn with_driver<F: FnMut(&mut Self::Driver) -> Output>(&mut self, f: &mut F) -> Output {


### PR DESCRIPTION
The increase in slice size caused a few tests to OOM in the s2n-quic repo: https://github.com/aws/s2n-quic/actions/runs/9430403115/job/25977870070?pr=2233