### PR TITLE
kani: remove use of kani::vec::any_vec

### DIFF
--- a/lib/bolero-kani/Cargo.toml
+++ b/lib/bolero-kani/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-kani"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "kani plugin for bolero"
 homepage = "https://github.com/camshaft/bolero"


### PR DESCRIPTION
`any_vec` seems to perform much worse than a stack array slice. This change removes `any_vec` entirely.