### PR TITLE
feat(bolero-generator): implement `bytes::Driver<T> where T: AsRef<[u8]>`

### DIFF
--- a/lib/bolero-generator/src/alloc/string.rs
+++ b/lib/bolero-generator/src/alloc/string.rs
@@ -130,11 +130,6 @@ fn string_type_test() {
 
 #[test]
 fn string_with_test() {
-    for _ in 0..100 {
-        let results = generator_test!(gen::<String>().with().len(32usize));
-        assert!(results.into_iter().any(|s| s.chars().count() == 32));
-        return;
-    }
-
-    panic!("failed to generate a valid string");
+    let results = generator_test!(gen::<String>().with().len(32usize));
+    assert!(results.into_iter().any(|s| s.chars().count() == 32));
 }

--- a/lib/bolero-generator/src/driver.rs
+++ b/lib/bolero-generator/src/driver.rs
@@ -8,7 +8,7 @@ use rand_core::RngCore;
 #[macro_use]
 mod macros;
 
-mod bytes;
+pub mod bytes;
 #[cfg(feature = "alloc")]
 pub mod cache;
 #[cfg(feature = "alloc")]

--- a/lib/bolero-generator/src/driver/macros.rs
+++ b/lib/bolero-generator/src/driver/macros.rs
@@ -63,7 +63,7 @@ macro_rules! gen_from_bytes {
 
         #[inline(always)]
         fn gen_variant(&mut self, variants: usize, base_case: usize) -> Option<usize> {
-            if self.depth == self.max_depth {
+            if self.depth() == self.max_depth() {
                 return Some(base_case);
             }
 


### PR DESCRIPTION
This change adds a `bytes::Driver<T>` that takes a value that implements `AsRef<[u8]>` and turns it into a driver. This is useful for passing around owned values of a driver without having to borrow slices and worry about lifetimes.

The `ByteSliceDriver` has been refactored to use this new driver internally.