### PR TITLE
feat: add `run` interface

### DIFF
--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -36,3 +36,10 @@ inherits = "dev"
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(kani)',
+  'cfg(bolero_should_panic)',
+]

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -52,6 +52,40 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(kani, kani::proof)]
+    fn exhaustive_test() {
+        let should_panic = should_panic();
+
+        check!()
+            .exhaustive()
+            .with_type()
+            .cloned()
+            .for_each(|(a, b)| assert!(add(a, b, should_panic) >= a));
+    }
+
+    #[test]
+    #[cfg_attr(kani, kani::proof)]
+    fn run_test() {
+        let should_panic = should_panic();
+
+        check!().run(|| {
+            let a = bolero::any();
+            let b = bolero::any();
+            assert!(add(a, b, should_panic) >= a)
+        });
+    }
+
+    #[test]
+    #[cfg_attr(kani, kani::proof)]
+    fn unit_test() {
+        let should_panic = should_panic();
+
+        let a = bolero::any();
+        let b = bolero::any();
+        assert!(add(a, b, should_panic) >= a);
+    }
+
+    #[test]
     fn panicking_generator_test() {
         #[derive(Debug)]
         struct T;

--- a/examples/boolean-tree/Cargo.toml
+++ b/examples/boolean-tree/Cargo.toml
@@ -17,3 +17,10 @@ inherits = "dev"
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(kani)',
+  'cfg(bolero_should_panic)',
+]

--- a/examples/rle-stack/Cargo.toml
+++ b/examples/rle-stack/Cargo.toml
@@ -14,3 +14,10 @@ inherits = "dev"
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(kani)',
+  'cfg(bolero_should_panic)',
+]

--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../../README.md"
 rust-version = "1.66.0"
 
 [features]
+any = ["bolero-generator/any"]
 cache = ["bolero-generator/alloc"]
 rng = ["rand", "rand_xoshiro", "bolero-generator/alloc"]
 

--- a/lib/bolero-engine/src/any.rs
+++ b/lib/bolero-engine/src/any.rs
@@ -1,0 +1,33 @@
+pub use bolero_generator::any::*;
+
+/// Runs a function that overrides the default driver for `bolero_generator::any` and
+/// returns the result
+#[cfg(not(kani))]
+pub fn run<D, F, R>(driver: Box<D>, test: F) -> (Box<D>, Result<bool, crate::panic::PanicError>)
+where
+    D: 'static + bolero_generator::driver::object::DynDriver + core::any::Any + Sized,
+    F: FnMut() -> R,
+    R: super::IntoResult,
+{
+    let mut test = core::panic::AssertUnwindSafe(test);
+    scope::with(driver, || {
+        crate::panic::catch(|| test.0().into_result().map(|_| true))
+    })
+}
+
+/// Runs a function that overrides the default driver for `bolero_generator::any` and
+/// returns the result
+#[cfg(kani)]
+pub fn run<F, R>(
+    driver: bolero_generator::kani::Driver,
+    mut test: F,
+) -> (
+    bolero_generator::kani::Driver,
+    Result<bool, crate::panic::PanicError>,
+)
+where
+    F: FnMut() -> R,
+    R: super::IntoResult,
+{
+    scope::with(driver, || test().into_result().map(|_| true))
+}

--- a/lib/bolero-engine/src/failure.rs
+++ b/lib/bolero-engine/src/failure.rs
@@ -21,6 +21,7 @@ impl<Input: Debug> Display for Failure<Input> {
         if let Some(seed) = &self.seed {
             writeln!(f, "BOLERO_RANDOM_SEED={}\n", seed)?;
         }
+
         writeln!(f, "Input: \n{:#?}\n", self.input)?;
         writeln!(f, "Error: \n{}", self.error)?;
 

--- a/lib/bolero-engine/src/lib.rs
+++ b/lib/bolero-engine/src/lib.rs
@@ -1,45 +1,50 @@
-pub use anyhow::Error;
-pub use bolero_generator::{
-    driver::{self, Driver},
-    TypeGenerator, ValueGenerator,
-};
-
-#[cfg(kani)]
-pub use bolero_generator::kani;
-
 pub type Seed = u128;
 
+#[cfg(feature = "any")]
+pub mod any;
+pub mod failure;
+pub mod input;
 #[cfg(not(kani))]
 pub mod panic;
 #[cfg(kani)]
 #[path = "./noop/panic.rs"]
 pub mod panic;
-
+mod result;
 #[cfg(feature = "rng")]
 pub mod rng;
 pub mod shrink;
-mod test;
-pub use test::*;
-
-pub mod failure;
-pub use crate::failure::Failure;
-
-pub mod input;
-pub use input::Input;
-
 #[doc(hidden)]
 pub mod target_location;
+mod test;
+
+pub use crate::failure::Failure;
+pub use anyhow::Error;
+#[cfg(kani)]
+pub use bolero_generator::kani;
+pub use bolero_generator::{
+    driver::{self, Driver},
+    TypeGenerator, ValueGenerator,
+};
+pub use input::Input;
+pub use result::IntoResult;
 #[doc(hidden)]
 pub use target_location::TargetLocation;
-
-mod result;
-pub use result::IntoResult;
+pub use test::*;
 
 /// Trait for defining an engine that executes a test
 pub trait Engine<T: Test>: Sized {
     type Output;
 
     fn run(self, test: T, options: driver::Options) -> Self::Output;
+}
+
+pub trait ScopedEngine {
+    type Output;
+
+    fn run<F, R>(self, test: F, options: driver::Options) -> Self::Output
+    where
+        F: FnMut() -> R,
+        R: IntoResult;
 }
 
 // TODO change this to `!` when stabilized

--- a/lib/bolero-generator/src/any/kani.rs
+++ b/lib/bolero-generator/src/any/kani.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 type Type = crate::kani::Driver;
 
 pub use core::convert::Infallible as Error;

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.66.0"
 
 [features]
 default = ["std"]
-std = ["alloc", "bolero-generator/std"]
+std = ["alloc", "bolero-engine/any", "bolero-generator/std"]
 alloc = ["bolero-generator/alloc"]
 arbitrary = ["bolero-generator/arbitrary"]
 

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -470,6 +470,17 @@ impl<E> TestTarget<ByteSliceGenerator, E, BorrowedInput> {
         let test = bolero_engine::BorrowedSliceTest::new(test);
         self.engine.run(test, self.driver_options)
     }
+
+    /// Iterate over all of the inputs and check the `TestTarget`
+    #[cfg(feature = "std")]
+    pub fn run<T, R>(self, test: T) -> E::Output
+    where
+        T: FnMut() -> R,
+        R: bolero_engine::IntoResult,
+        E: bolero_engine::ScopedEngine,
+    {
+        self.engine.run(test, self.driver_options)
+    }
 }
 
 impl<E> TestTarget<ByteSliceGenerator, E, ClonedInput> {

--- a/tests/src/engines.rs
+++ b/tests/src/engines.rs
@@ -70,6 +70,8 @@ impl Test {
                 &[
                     "tests::add_test",
                     "tests::other_test",
+                    "tests::exhaustive_test",
+                    "tests::run_test",
                     "fuzz_bytes",
                     "fuzz_generator",
                     "fuzz_operations",


### PR DESCRIPTION
This change adds the ability to use generator functions inside of harnesses without having to specify the inputs up front.

```rust
use bolero::*;

check!().run(|| {
    let _ = any::<u64>();
    let _ = (0..4).any();
    let _ = [1, 2, 3].pick();
    let _ = gen::<Vec<u8>>().with().len(2..4).any();
});
```

Note that there are a couple of caveats to this interface:

* This uses thread-local variables for each call to `any`, which can have a bit of overhead, so it's generally preferred to use the `.with_type` and `.with_generator` if possible
* The harness does not currently track inputs for displaying when things fail so it may be a bit more difficult to debug. This may change in the future.
* Shrinking is currently not implemented but will be at a later time.