### PR TITLE
build(deps): update rand, rand_xoshiro, and getrandom requirements

### DIFF
--- a/bin/cargo-bolero/src/random.rs
+++ b/bin/cargo-bolero/src/random.rs
@@ -153,7 +153,7 @@ fn handle_worker_out<B: 'static + Send + std::io::Read>(
 
 fn handle_worker_status(mut child: Child, chan: mpsc::Sender<Message>) {
     std::thread::spawn(move || {
-        let success = child.wait().map_or(false, |status| status.success());
+        let success = child.wait().is_ok_and(|status| status.success());
 
         let _ = chan.send(Message::Shutdown { success });
     });

--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -21,16 +21,16 @@ anyhow = "1"
 bolero-generator = { version = "0.12", path = "../bolero-generator", default-features = false }
 lazy_static = "1"
 pretty-hex = { version = "0.4", default-features = false }
-rand = { version = "0.8", optional = true }
-rand_xoshiro = { version = "0.6", optional = true }
+rand = { version = "0.9", optional = true }
+rand_xoshiro = { version = "0.7", optional = true }
 
 [target.'cfg(not(kani))'.dependencies]
 backtrace = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 bolero-generator = { version = "0.12", path = "../bolero-generator", features = ["std"] }
-rand = "0.8"
-rand_xoshiro = "0.6"
+rand = "0.9"
+rand_xoshiro = "0.7"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-generator/Cargo.toml
+++ b/lib/bolero-generator/Cargo.toml
@@ -15,19 +15,19 @@ rust-version = "1.66.0"
 default = ["any", "either", "std"]
 any = ["getrandom", "rand_xoshiro", "std"]
 std = ["alloc", "either/use_std"]
-alloc = ["rand_core/alloc"]
+alloc = []
 
 [dependencies]
 arbitrary = { version = "1.0", optional = true }
 bolero-generator-derive = { version = "0.12", path = "../bolero-generator-derive" }
 either = { version = "1.5", default-features = false, optional = true }
-getrandom = { version = "0.2", optional = true }
-rand_core = { version = "0.6", default-features = false }
-rand_xoshiro = { version = "0.6", optional = true }
+getrandom = { version = "0.3", optional = true }
+rand_core = { version = "0.9", default-features = false }
+rand_xoshiro = { version = "0.7", optional = true }
 
 [dev-dependencies]
 insta = "1"
-rand = "0.8"
+rand = "0.9"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-generator/src/any/default.rs
+++ b/lib/bolero-generator/src/any/default.rs
@@ -27,7 +27,7 @@ fn default() -> impl crate::Driver {
 
     let mut seed = [42; 16];
     // make a best effort to get random seeds
-    let _ = getrandom::getrandom(&mut seed);
+    let _ = getrandom::fill(&mut seed);
     let rng = Xoshiro128PlusPlus::from_seed(seed);
     crate::driver::Rng::new(rng, &Default::default())
 }

--- a/lib/bolero-generator/src/driver.rs
+++ b/lib/bolero-generator/src/driver.rs
@@ -3,7 +3,7 @@ use crate::{
     TypeGenerator, ValueGenerator,
 };
 use core::ops::Bound;
-use rand_core::RngCore;
+use rand_core::TryRngCore;
 
 #[macro_use]
 mod macros;

--- a/lib/bolero-generator/src/driver/bytes.rs
+++ b/lib/bolero-generator/src/driver/bytes.rs
@@ -135,7 +135,7 @@ impl<'a> ByteSliceDriver<'a> {
     }
 }
 
-impl<'a> FillBytes for ByteSliceDriver<'a> {
+impl FillBytes for ByteSliceDriver<'_> {
     #[inline]
     fn peek_bytes(&mut self, offset: usize, bytes: &mut [u8]) -> Option<()> {
         self.0.peek_bytes(offset, bytes)
@@ -147,7 +147,7 @@ impl<'a> FillBytes for ByteSliceDriver<'a> {
     }
 }
 
-impl<'a> super::Driver for ByteSliceDriver<'a> {
+impl super::Driver for ByteSliceDriver<'_> {
     gen_from_bytes!();
 
     #[inline]

--- a/lib/bolero-generator/src/driver/cache.rs
+++ b/lib/bolero-generator/src/driver/cache.rs
@@ -93,14 +93,14 @@ impl<'a, I: super::Driver> Driver<'a, I> {
     }
 }
 
-impl<'a, I: super::Driver> AsRef<I> for Driver<'a, I> {
+impl<I: super::Driver> AsRef<I> for Driver<'_, I> {
     #[inline]
     fn as_ref(&self) -> &I {
         &self.inner
     }
 }
 
-impl<'a, I: super::Driver> super::Driver for Driver<'a, I> {
+impl<I: super::Driver> super::Driver for Driver<'_, I> {
     #[inline(always)]
     fn depth(&self) -> usize {
         self.inner.depth()

--- a/lib/bolero-generator/src/driver/exhaustive.rs
+++ b/lib/bolero-generator/src/driver/exhaustive.rs
@@ -338,11 +338,6 @@ impl rand_core::RngCore for Rng<'_> {
         let value = self.0.select((1 << dest.len()) * 8);
         dest.copy_from_slice(&value.to_be_bytes()[..dest.len()]);
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/lib/bolero-generator/src/driver/object.rs
+++ b/lib/bolero-generator/src/driver/object.rs
@@ -62,7 +62,7 @@ fn hint_fn<F: FnOnce() -> (usize, Option<usize>)>(f: F) -> impl FnMut() -> (usiz
 
 pub struct Borrowed<'a>(pub &'a mut dyn DynDriver);
 
-impl<'a> Driver for Borrowed<'a> {
+impl Driver for Borrowed<'_> {
     #[inline]
     fn depth(&self) -> usize {
         self.0.depth()

--- a/lib/bolero-generator/src/driver/rng.rs
+++ b/lib/bolero-generator/src/driver/rng.rs
@@ -153,8 +153,7 @@ impl<R: TryRngCore> Driver for Rng<R> {
         let max = max
             .unwrap_or(usize::MAX)
             // make sure max is at least min
-            .max(min)
-            .min(self.remaining_len())
+            .clamp(min, self.remaining_len())
             .min(Buffer::MAX_CAPACITY);
 
         let len = self.gen_usize(Bound::Included(&min), Bound::Included(&max))?;

--- a/lib/bolero-generator/src/driver/rng.rs
+++ b/lib/bolero-generator/src/driver/rng.rs
@@ -6,7 +6,7 @@ pub(crate) use buffer_alloc::Buffer;
 pub(crate) use buffer_no_alloc::Buffer;
 
 #[derive(Debug)]
-pub struct Rng<R: RngCore> {
+pub struct Rng<R: TryRngCore> {
     rng: R,
     depth: usize,
     max_depth: usize,
@@ -16,7 +16,7 @@ pub struct Rng<R: RngCore> {
     buffer: Buffer,
 }
 
-impl<R: RngCore> Rng<R> {
+impl<R: TryRngCore> Rng<R> {
     pub fn new(rng: R, options: &Options) -> Self {
         Self {
             rng,
@@ -54,7 +54,7 @@ impl<R: RngCore> Rng<R> {
     }
 }
 
-impl<R: RngCore> AsRef<R> for Rng<R> {
+impl<R: TryRngCore> AsRef<R> for Rng<R> {
     #[inline]
     fn as_ref(&self) -> &R {
         &self.rng
@@ -62,8 +62,8 @@ impl<R: RngCore> AsRef<R> for Rng<R> {
 }
 
 #[inline]
-fn fill_bytes<R: RngCore>(rng: &mut R, bytes: &mut [u8]) -> Option<()> {
-    if RngCore::try_fill_bytes(rng, bytes).is_err() {
+fn fill_bytes<R: TryRngCore>(rng: &mut R, bytes: &mut [u8]) -> Option<()> {
+    if TryRngCore::try_fill_bytes(rng, bytes).is_err() {
         // if the rng fails to fill the remaining bytes, then we just start returning 0s
         for byte in bytes.iter_mut() {
             *byte = 0;
@@ -79,7 +79,7 @@ macro_rules! impl_sample {
         fn $sample(&mut self) -> Option<$ty> {
             if self.has_remaining() {
                 self.consumed_len += core::mem::size_of::<$ty>();
-                Some(self.rng.$inner() as $ty)
+                Some(self.rng.$inner().unwrap_or_default() as $ty)
             } else {
                 Some(0)
             }
@@ -87,7 +87,7 @@ macro_rules! impl_sample {
     };
 }
 
-impl<R: RngCore> FillBytes for Rng<R> {
+impl<R: TryRngCore> FillBytes for Rng<R> {
     // prefer sampling the larger values since it's faster to pull from the RNG
     const SHOULD_SHRINK: bool = false;
 
@@ -105,26 +105,26 @@ impl<R: RngCore> FillBytes for Rng<R> {
     fn sample_bool(&mut self) -> Option<bool> {
         if self.has_remaining() {
             self.consumed_len += 1;
-            let value = self.rng.next_u32();
+            let value = self.rng.try_next_u32().unwrap_or_default();
             Some(value < (u32::MAX / 2))
         } else {
             Some(false)
         }
     }
 
-    impl_sample!(sample_u8, u8, next_u32);
-    impl_sample!(sample_i8, i8, next_u32);
-    impl_sample!(sample_u16, u16, next_u32);
-    impl_sample!(sample_i16, i16, next_u32);
-    impl_sample!(sample_u32, u32, next_u32);
-    impl_sample!(sample_i32, i32, next_u32);
-    impl_sample!(sample_u64, u64, next_u64);
-    impl_sample!(sample_i64, i64, next_u64);
-    impl_sample!(sample_usize, usize, next_u64);
-    impl_sample!(sample_isize, isize, next_u64);
+    impl_sample!(sample_u8, u8, try_next_u32);
+    impl_sample!(sample_i8, i8, try_next_u32);
+    impl_sample!(sample_u16, u16, try_next_u32);
+    impl_sample!(sample_i16, i16, try_next_u32);
+    impl_sample!(sample_u32, u32, try_next_u32);
+    impl_sample!(sample_i32, i32, try_next_u32);
+    impl_sample!(sample_u64, u64, try_next_u64);
+    impl_sample!(sample_i64, i64, try_next_u64);
+    impl_sample!(sample_usize, usize, try_next_u64);
+    impl_sample!(sample_isize, isize, try_next_u64);
 }
 
-impl<R: RngCore> Driver for Rng<R> {
+impl<R: TryRngCore> Driver for Rng<R> {
     gen_from_bytes!();
 
     #[inline]
@@ -179,7 +179,7 @@ mod buffer_alloc {
         pub const MAX_CAPACITY: usize = isize::MAX as _;
 
         #[inline]
-        pub fn fill<R: RngCore>(&mut self, len: usize, rng: &mut R) -> Option<()> {
+        pub fn fill<R: TryRngCore>(&mut self, len: usize, rng: &mut R) -> Option<()> {
             let data = &mut self.bytes;
 
             let initial_len = data.len();
@@ -232,7 +232,7 @@ mod buffer_no_alloc {
         pub const MAX_CAPACITY: usize = 256;
 
         #[inline]
-        pub fn fill<R: RngCore>(&mut self, len: usize, rng: &mut R) -> Option<()> {
+        pub fn fill<R: TryRngCore>(&mut self, len: usize, rng: &mut R) -> Option<()> {
             if cfg!(test) {
                 assert!(len <= Self::MAX_CAPACITY);
             }

--- a/lib/bolero-generator/src/lib.rs
+++ b/lib/bolero-generator/src/lib.rs
@@ -159,7 +159,7 @@ pub trait ValueGenerator: Sized {
     }
 }
 
-impl<'a, T: ValueGenerator> ValueGenerator for &'a T {
+impl<T: ValueGenerator> ValueGenerator for &T {
     type Output = T::Output;
 
     #[inline]

--- a/lib/bolero-generator/src/result.rs
+++ b/lib/bolero-generator/src/result.rs
@@ -205,7 +205,7 @@ impl<V: ValueGenerator> ValueGenerator for OptionGenerator<V> {
             2,
             0,
             |driver, new_selection| {
-                let prev_selection = if value.is_some() { 1 } else { 0 };
+                let prev_selection = usize::from(value.is_some());
 
                 if prev_selection == new_selection {
                     match value {

--- a/lib/bolero-generator/src/testing.rs
+++ b/lib/bolero-generator/src/testing.rs
@@ -9,10 +9,7 @@ macro_rules! generator_test {
 
         let options = Options::default();
 
-        let mut rng_driver = Rng::new(
-            rand::thread_rng(),
-            &options.clone().with_max_len(8 * 1024 * 1024),
-        );
+        let mut rng_driver = Rng::new(rand::rng(), &options.clone().with_max_len(8 * 1024 * 1024));
 
         let mut results = vec![];
 
@@ -64,7 +61,7 @@ macro_rules! generator_no_clone_test {
 
         let options = Options::default();
 
-        let mut rng_driver = Rng::new(rand::thread_rng(), &options);
+        let mut rng_driver = Rng::new(rand::rng(), &options);
 
         let inputs = $crate::gen::<Vec<_>>()
             .with()

--- a/lib/bolero-generator/src/trace.rs
+++ b/lib/bolero-generator/src/trace.rs
@@ -113,7 +113,7 @@ struct Driver<'a, D: crate::Driver, O: std::io::Write> {
     formatter: Formatter<O>,
 }
 
-impl<'a, D: crate::Driver, O: std::io::Write> Driver<'a, D, O> {
+impl<D: crate::Driver, O: std::io::Write> Driver<'_, D, O> {
     #[inline]
     fn emit_block<F: FnOnce(&mut Self) -> Option<Ret>, Ret>(
         &mut self,
@@ -177,7 +177,7 @@ macro_rules! gen_prim {
     };
 }
 
-impl<'a, D: crate::Driver, O: std::io::Write> crate::Driver for Driver<'a, D, O> {
+impl<D: crate::Driver, O: std::io::Write> crate::Driver for Driver<'_, D, O> {
     #[inline]
     fn depth(&self) -> usize {
         self.inner.depth()

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -33,17 +33,17 @@ bolero-honggfuzz = { version = "0.12", path = "../bolero-honggfuzz" }
 
 [target.'cfg(fuzzing_random)'.dependencies]
 bolero-engine = { version = "0.12", path = "../bolero-engine", features = ["cache", "rng"] }
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 
 [target.'cfg(kani)'.dependencies]
 bolero-kani = { version = "0.12", path = "../bolero-kani" }
 
 [target.'cfg(not(any(fuzzing, kani)))'.dependencies]
 bolero-engine = { version = "0.12", path = "../bolero-engine", features = ["cache", "rng"] }
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.9"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -111,7 +111,6 @@ mod tests;
 ///     // implement checks here
 /// });
 /// ```
-
 #[macro_export]
 macro_rules! check {
     () => {{

--- a/lib/bolero/src/test/input.rs
+++ b/lib/bolero/src/test/input.rs
@@ -82,7 +82,7 @@ pub struct BufferedRng<'a> {
     buffer: &'a mut Vec<u8>,
 }
 
-impl<'a> rand::RngCore for BufferedRng<'a> {
+impl rand::RngCore for BufferedRng<'_> {
     fn next_u32(&mut self) -> u32 {
         let mut data = [0; 4];
         self.fill_bytes(&mut data);
@@ -123,7 +123,7 @@ pub struct ReplayRng<'a> {
     buffer: &'a [u8],
 }
 
-impl<'a> rand::RngCore for ReplayRng<'a> {
+impl rand::RngCore for ReplayRng<'_> {
     fn next_u32(&mut self) -> u32 {
         let mut data = [0; 4];
         self.fill_bytes(&mut data);
@@ -150,7 +150,7 @@ pub struct RngReplayInput<'a> {
     pub buffer: &'a mut Vec<u8>,
 }
 
-impl<'a> bolero_engine::shrink::Input for RngReplayInput<'a> {
+impl bolero_engine::shrink::Input for RngReplayInput<'_> {
     type Driver<'d>
         = driver::Rng<ReplayRng<'d>>
     where
@@ -164,14 +164,14 @@ impl<'a> bolero_engine::shrink::Input for RngReplayInput<'a> {
     }
 }
 
-impl<'a> AsRef<Vec<u8>> for RngReplayInput<'a> {
+impl AsRef<Vec<u8>> for RngReplayInput<'_> {
     #[inline]
     fn as_ref(&self) -> &Vec<u8> {
         self.buffer
     }
 }
 
-impl<'a> AsMut<Vec<u8>> for RngReplayInput<'a> {
+impl AsMut<Vec<u8>> for RngReplayInput<'_> {
     #[inline]
     fn as_mut(&mut self) -> &mut Vec<u8> {
         self.buffer
@@ -183,7 +183,7 @@ pub struct ExhastiveInput<'a> {
     pub driver: &'a mut driver::exhaustive::Driver,
 }
 
-impl<'a, Output> Input<Output> for ExhastiveInput<'a> {
+impl<Output> Input<Output> for ExhastiveInput<'_> {
     type Driver = driver::exhaustive::Driver;
 
     fn with_slice<F: FnMut(&[u8]) -> Output>(&mut self, f: &mut F) -> Output {
@@ -196,14 +196,14 @@ impl<'a, Output> Input<Output> for ExhastiveInput<'a> {
     }
 }
 
-impl<'a> AsRef<Vec<u8>> for ExhastiveInput<'a> {
+impl AsRef<Vec<u8>> for ExhastiveInput<'_> {
     #[inline]
     fn as_ref(&self) -> &Vec<u8> {
         self.buffer
     }
 }
 
-impl<'a> AsMut<Vec<u8>> for ExhastiveInput<'a> {
+impl AsMut<Vec<u8>> for ExhastiveInput<'_> {
     #[inline]
     fn as_mut(&mut self) -> &mut Vec<u8> {
         self.buffer

--- a/lib/bolero/src/test/input.rs
+++ b/lib/bolero/src/test/input.rs
@@ -95,14 +95,9 @@ impl<'a> rand::RngCore for BufferedRng<'a> {
         u64::from_le_bytes(data)
     }
 
-    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), rand::Error> {
-        self.rng.try_fill_bytes(bytes)?;
-        self.buffer.extend_from_slice(bytes);
-        Ok(())
-    }
-
     fn fill_bytes(&mut self, bytes: &mut [u8]) {
-        self.try_fill_bytes(bytes).unwrap()
+        self.rng.fill_bytes(bytes);
+        self.buffer.extend_from_slice(bytes);
     }
 }
 
@@ -141,18 +136,13 @@ impl<'a> rand::RngCore for ReplayRng<'a> {
         u64::from_le_bytes(data)
     }
 
-    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), rand::Error> {
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
         let len = self.buffer.len().min(bytes.len());
         let (copy_from, remaining) = self.buffer.split_at(len);
         let (copy_to, fill_to) = bytes.split_at_mut(len);
         copy_to.copy_from_slice(copy_from);
         fill_to.fill(0);
         self.buffer = remaining;
-        Ok(())
-    }
-
-    fn fill_bytes(&mut self, bytes: &mut [u8]) {
-        self.try_fill_bytes(bytes).unwrap()
     }
 }
 

--- a/lib/bolero/src/test/mod.rs
+++ b/lib/bolero/src/test/mod.rs
@@ -112,7 +112,7 @@ impl TestEngine {
 
         let iterations = self.rng_cfg.iterations_or_default();
         // use StdRng for high entropy seeds
-        let mut seed_rng = StdRng::from_entropy();
+        let mut seed_rng = StdRng::from_os_rng();
 
         (0..iterations).map(move |_| {
             let mut seed = [0; size_of::<Seed>()];

--- a/lib/bolero/src/test/report.rs
+++ b/lib/bolero/src/test/report.rs
@@ -96,7 +96,7 @@ impl Stats {
         // only report valid percentage if we drop below 100%
         struct Estimate<'a>(&'a Stats);
 
-        impl<'a> fmt::Display for Estimate<'a> {
+        impl fmt::Display for Estimate<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self.0.estimate {
                     Some(estimate) => {


### PR DESCRIPTION
### Release Summary:

Update `rand` requirement in Bolero to unblock `bach` and `s2n-quic` rand updates.

### Resolved issues:

### Description of changes:
I have updated the versions for `rand`, `rand_xoshiro`, and `getrandom` versions to be the most up to date versions. In the new version of `rand`, `try_fill_bytes()` trait has been removed, so I have removed those from Bolero accordingly. `alloc` is fully removed from `rand_core`, so we don't pull `alloc` from `rand_core`. Most of changes are reflecting recent renames in those dependencies.

We are updating these requirements to unlock `s2n-quic`'s rand updates. A tracking issue can be found in this link: https://github.com/aws/s2n-quic/issues/2479.

### Call-outs:

* In `rand v0.9.0`, the original `RngCore` is split into two traits. Here is the [doc](https://rust-random.github.io/book/update-0.9.html#core-traits). Here is how I handled it:
    * For `exhaustive.rs`, `lib/bolero/src/test/input.rs`, we will support `RngCore` since the original implementation makes the Core infallible.
    * For the actual rng driver in `lib/bolero-generator/src/driver/rng.rs`, we will let it takes input from `TryRngCore`.
    * This works because the new `RngCore` itself is equivalent to a `TryRngCore` with a infallible error type.
* There are some changes, which involves getting ride of [needless lifetime](https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes) and [unnecessary map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or). They are trying to fix clippy issue.

### Testing:
This change will be tested by the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.