### PR TITLE
build(deps): bump JamesIves/github-pages-deploy-action

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -22,6 +22,6 @@ jobs:
       - run: mdbook build book
 
       - name: Build and Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.6.9
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           folder: target/book


### PR DESCRIPTION
This PR updates `github-pages-deploy-action` to the latest version. I have rebase this branch with main, so that all those clippy issues will be fixed.

Successully merging this PR will close the [dependabot PR](https://github.com/camshaft/bolero/pull/269). I tried [rebasing the previous PR](https://github.com/camshaft/bolero/pull/269#issuecomment-2685773882), but don't have permissions.

The CI running with MSRV 1.66.0 will fail, because it [no longer supports `kani`](https://github.com/camshaft/bolero/pull/270#issuecomment-2679739143).