### PR TITLE
chore: release 0.13.0

### DIFF
--- a/bin/cargo-bolero/Cargo.toml
+++ b/bin/cargo-bolero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bolero"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "cargo command for running bolero fuzz tests"
 homepage = "https://github.com/camshaft/bolero"
@@ -21,8 +21,8 @@ libfuzzer = []
 [dependencies]
 anyhow = "1.0"
 bit-set = "0.8"
-bolero-afl = { version = "0.12", path = "../../lib/bolero-afl", default-features = false, features = ["bin"], optional = true }
-bolero-honggfuzz = { version = "0.12", path = "../../lib/bolero-honggfuzz", default-features = false, features = ["bin"], optional = true }
+bolero-afl = { version = "0.13", path = "../../lib/bolero-afl", default-features = false, features = ["bin"], optional = true }
+bolero-honggfuzz = { version = "0.13", path = "../../lib/bolero-honggfuzz", default-features = false, features = ["bin"], optional = true }
 cargo_metadata = "0.19"
 humantime = "2"
 lazy_static = "1"
@@ -34,7 +34,7 @@ tar = "0.4"
 tempfile = "3"
 
 [dev-dependencies]
-bolero = { version = "0.12", path = "../../lib/bolero" }
+bolero = { version = "0.13", path = "../../lib/bolero" }
 
 [[test]]
 name = "fuzz_bytes"

--- a/lib/bolero-afl/Cargo.toml
+++ b/lib/bolero-afl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-afl"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bythewc@amazon.com>"]
 description = "afl plugin for bolero"
 homepage = "https://github.com/camshaft/bolero"
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine", optional = true }
+bolero-engine = { version = "0.13", path = "../bolero-engine", optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-engine"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "fuzz and property testing framework"
 homepage = "https://github.com/camshaft/bolero"
@@ -18,7 +18,7 @@ rng = ["rand", "rand_xoshiro", "bolero-generator/alloc"]
 
 [dependencies]
 anyhow = "1"
-bolero-generator = { version = "0.12", path = "../bolero-generator", default-features = false }
+bolero-generator = { version = "0.13", path = "../bolero-generator", default-features = false }
 lazy_static = "1"
 pretty-hex = { version = "0.4", default-features = false }
 rand = { version = "0.9", optional = true }
@@ -28,7 +28,7 @@ rand_xoshiro = { version = "0.7", optional = true }
 backtrace = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-bolero-generator = { version = "0.12", path = "../bolero-generator", features = ["std"] }
+bolero-generator = { version = "0.13", path = "../bolero-generator", features = ["std"] }
 rand = "0.9"
 rand_xoshiro = "0.7"
 

--- a/lib/bolero-generator-derive/Cargo.toml
+++ b/lib/bolero-generator-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-generator-derive"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "value generator for testing and fuzzing"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero-generator/Cargo.toml
+++ b/lib/bolero-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-generator"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "value generator for testing and fuzzing"
 homepage = "https://github.com/camshaft/bolero"
@@ -19,7 +19,7 @@ alloc = []
 
 [dependencies]
 arbitrary = { version = "1.0", optional = true }
-bolero-generator-derive = { version = "0.12", path = "../bolero-generator-derive" }
+bolero-generator-derive = { version = "0.13", path = "../bolero-generator-derive" }
 either = { version = "1.5", default-features = false, optional = true }
 getrandom = { version = "0.3", optional = true }
 rand_core = { version = "0.9", default-features = false }

--- a/lib/bolero-honggfuzz/Cargo.toml
+++ b/lib/bolero-honggfuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-honggfuzz"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "honggfuzz plugin for bolero"
 homepage = "https://github.com/camshaft/bolero"
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine", optional = true }
+bolero-engine = { version = "0.13", path = "../bolero-engine", optional = true }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-kani/Cargo.toml
+++ b/lib/bolero-kani/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-kani"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "kani plugin for bolero"
 homepage = "https://github.com/camshaft/bolero"
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine", optional = true }
+bolero-engine = { version = "0.13", path = "../bolero-engine", optional = true }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-libfuzzer/Cargo.toml
+++ b/lib/bolero-libfuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-libfuzzer"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "libfuzzer plugin for bolero"
 homepage = "https://github.com/camshaft/bolero"
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine", features = ["cache"], optional = true }
+bolero-engine = { version = "0.13", path = "../bolero-engine", features = ["cache"], optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "fuzz and property testing front-end"
 homepage = "https://github.com/camshaft/bolero"
@@ -18,28 +18,28 @@ alloc = ["bolero-generator/alloc"]
 arbitrary = ["bolero-generator/arbitrary"]
 
 [dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine" }
-bolero-generator = { version = "0.12", path = "../bolero-generator", default-features = false }
+bolero-engine = { version = "0.13", path = "../bolero-engine" }
+bolero-generator = { version = "0.13", path = "../bolero-generator", default-features = false }
 cfg-if = "1"
 
 [target.'cfg(fuzzing_afl)'.dependencies]
-bolero-afl = { version = "0.12", path = "../bolero-afl" }
+bolero-afl = { version = "0.13", path = "../bolero-afl" }
 
 [target.'cfg(fuzzing_libfuzzer)'.dependencies]
-bolero-libfuzzer = { version = "0.12", path = "../bolero-libfuzzer" }
+bolero-libfuzzer = { version = "0.13", path = "../bolero-libfuzzer" }
 
 [target.'cfg(fuzzing_honggfuzz)'.dependencies]
-bolero-honggfuzz = { version = "0.12", path = "../bolero-honggfuzz" }
+bolero-honggfuzz = { version = "0.13", path = "../bolero-honggfuzz" }
 
 [target.'cfg(fuzzing_random)'.dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine", features = ["cache", "rng"] }
+bolero-engine = { version = "0.13", path = "../bolero-engine", features = ["cache", "rng"] }
 rand = { version = "0.9" }
 
 [target.'cfg(kani)'.dependencies]
-bolero-kani = { version = "0.12", path = "../bolero-kani" }
+bolero-kani = { version = "0.13", path = "../bolero-kani" }
 
 [target.'cfg(not(any(fuzzing, kani)))'.dependencies]
-bolero-engine = { version = "0.12", path = "../bolero-engine", features = ["cache", "rng"] }
+bolero-engine = { version = "0.13", path = "../bolero-engine", features = ["cache", "rng"] }
 rand = { version = "0.9" }
 
 [dev-dependencies]


### PR DESCRIPTION
Bolero v0.13.0 release.

This is a step in https://github.com/aws/s2n-quic/issues/2479.