### PR TITLE
fix: remove link-dead-code, that causes linker failures on macos

### DIFF
--- a/bin/cargo-bolero/src/project.rs
+++ b/bin/cargo-bolero/src/project.rs
@@ -143,7 +143,6 @@ impl Project {
             "-Ctarget-cpu=native",
             "-Cdebuginfo=2",
             "-Coverflow_checks",
-            "-Clink-dead-code",
         ]
         .iter()
         .chain({


### PR DESCRIPTION
Without this, I'm getting the following error on my production system:
```
          Undefined symbols for architecture arm64:
            "___getrandom_custom", referenced from:
                getrandom::custom::getrandom_inner::he09b0ce5a718e198 in libgetrandom-de720050bd3ff58d.rlib[3](getrandom-de720050bd3ff58d.getrandom.67592e623299eaa1-cgu.0.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I couldn't find motivation for this specific flag, so I'm suggesting this change to just remove it. As always, thank you for your work on bolero! 😄 