### PR TITLE
Fallback to `::bolero_generator` as crate name in derive macro

### DIFF
--- a/lib/bolero-generator-derive/src/lib.rs
+++ b/lib/bolero-generator-derive/src/lib.rs
@@ -30,7 +30,9 @@ fn crate_path() -> TokenStream2 {
         let krate = crate_ident(krate);
         return quote!(#krate::generator::bolero_generator);
     }
-    panic!("current crate seems to import neither bolero nor bolero-generator, but does use the TypeGenerator derive macro")
+    // fallback to using `::bolero_generator` if for whatever reason
+    // we can't find the crate in the `Cargo.toml`
+    quote!(::bolero_generator)
 }
 
 /// Derive the an implementation of `TypeGenerator` for the given type.


### PR DESCRIPTION
For reasons ™, we link bolero_generator against a target crate using the rustc flag `--extern`. This breaks the derive macro because it expects to find either `bolero` or `bolero_generator` in Cargo.toml. This PR defaults to using the crate name `bolero_generator` instead of panicking when we can't find bolero in Cargo.toml.