### PR TITLE
Add Tyche Analysis Tool Support

### DIFF
--- a/lib/bolero-engine/src/target_location.rs
+++ b/lib/bolero-engine/src/target_location.rs
@@ -175,7 +175,7 @@ impl TargetLocation {
         components.join("__")
     }
 
-    fn item_path(&self) -> String {
+    pub fn item_path(&self) -> String {
         Self::format_symbol_name(self.item_path)
     }
 

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -21,7 +21,8 @@ arbitrary = ["bolero-generator/arbitrary"]
 bolero-engine = { version = "0.13", path = "../bolero-engine" }
 bolero-generator = { version = "0.13", path = "../bolero-generator", default-features = false }
 cfg-if = "1"
-
+serde_json = "1.0"
+lazy_static = "1.5.0"
 [target.'cfg(fuzzing_afl)'.dependencies]
 bolero-afl = { version = "0.13", path = "../bolero-afl" }
 

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(kani)] {
         pub use bolero_kani::KaniEngine as DefaultEngine;
     } else {
-        mod test;
+        pub mod test;
 
         /// The default engine used when defining a test target
         pub use crate::test::TestEngine as DefaultEngine;

--- a/lib/bolero/src/test/mod.rs
+++ b/lib/bolero/src/test/mod.rs
@@ -179,7 +179,7 @@ impl TestEngine {
             .chain(self.rng_tests().map(|t| t.into()))
     }
 
-    fn run_with_value<T>(self, mut test: T, options: driver::Options) -> bolero_engine::Never
+    fn run_with_value<T>(self, test: T, options: driver::Options) -> bolero_engine::Never
     where
         T: Test,
         T::Value: core::fmt::Debug,

--- a/lib/bolero/src/test/outcome.rs
+++ b/lib/bolero/src/test/outcome.rs
@@ -1,0 +1,212 @@
+use bolero_engine::TargetLocation;
+use core::{fmt, time::Duration};
+use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use std::collections::HashMap;
+use serde_json::json;
+use std::io::Write;
+
+pub enum ExitReason {
+    MaxDurationExceeded { limit: Duration, default: bool },
+    TestFailure,
+}
+
+impl fmt::Display for ExitReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExitReason::MaxDurationExceeded { limit, default } => {
+                write!(
+                    f,
+                    "max duration ({:?}{}) exceeded",
+                    limit,
+                    if *default { " - default" } else { "" }
+                )
+            }
+            ExitReason::TestFailure => write!(f, "test failure"),
+        }
+    }
+}
+
+pub struct Outcome<'a> {
+    location: &'a TargetLocation,
+    start_time: Instant,
+    corpus_input: u64,
+    rng_input: u64,
+    exhaustive_input: u64,
+    total: u64,
+    exit_reason: Option<ExitReason>,
+    features: serde_json::Value,
+    arguments: serde_json::Value,
+    coverage: serde_json::Value,
+    representation: String,
+    json_time: std::time::Duration,
+}
+
+impl fmt::Display for Outcome<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let runtime = self.start_time.elapsed();
+
+        if let Some(name) = self.location.test_name.as_ref() {
+            write!(f, "test {name} ...\t")?;
+        } else {
+            write!(f, "test {} ...\t", self.location.item_path())?;
+        }
+
+        write!(f, "run time: {runtime:?} | ")?;
+
+        let mut ips = self.total as f64 / runtime.as_secs_f64();
+        if ips > 10.0 {
+            ips = ips.round();
+            write!(f, "iterations/s: {ips}")?;
+        } else {
+            write!(f, "iterations/s: {ips:0.2}")?;
+        }
+
+        for (label, count) in [
+            ("corpus inputs", self.corpus_input),
+            ("rng inputs", self.rng_input),
+            ("exhaustive inputs", self.exhaustive_input),
+        ] {
+            if count > 0 {
+                write!(f, " | {label}: {count}")?;
+            }
+        }
+
+        if let Some(reason) = &self.exit_reason {
+            write!(f, " | exit reason: {}", reason)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Outcome<'a> {
+    pub fn new(location: &'a TargetLocation, start_time: Instant) -> Self {
+        Self {
+            location,
+            start_time,
+            corpus_input: 0,
+            rng_input: 0,
+            exhaustive_input: 0,
+            total: 0,
+            representation: String::new(),
+            exit_reason: None,
+            features: json!({}),
+            arguments: json!({}),
+            coverage: json!({}),
+            json_time: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards"),
+        }
+    }
+
+
+    pub fn on_named_test(&mut self, test: &super::input::Test) {
+        match test {
+            super::input::Test::Rng(_) => self.on_rng_input(),
+            super::input::Test::File(_) => self.on_corpus_input(),
+        }
+    }
+
+    pub fn on_corpus_input(&mut self) {
+        progress();
+        self.corpus_input += 1;
+        self.total += 1;
+    }
+
+    pub fn on_rng_input(&mut self) {
+        progress();
+        self.rng_input += 1;
+        self.total += 1;
+    }
+
+    pub fn on_exhaustive_input(&mut self) {
+        self.exhaustive_input += 1;
+        self.total += 1;
+    }
+
+    pub fn on_exit(&mut self, reason: ExitReason) {
+        self.exit_reason = Some(reason);
+    }
+    pub fn set_representation(&mut self, representation: String) {
+        self.representation = representation;
+    }
+    pub fn set_features(&mut self, features: Option<HashMap<String, String>>) {
+        self.features = match features {
+            None => json!({}),
+            Some(map) => serde_json::json!(map),
+        };
+    }
+    pub fn output_json(&self) -> std::io::Result<()>{
+        let status = match &self.exit_reason {
+            Some(ExitReason::TestFailure) => "failed",
+            Some(ExitReason::MaxDurationExceeded { .. }) => "timed out",
+            None => "passed",
+        };
+
+        let status_reason = match &self.exit_reason {
+            Some(reason) => reason.to_string(),
+            None => String::new(),
+        };
+
+        let property = self.location.test_name.as_ref()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| self.location.item_path.to_string());
+
+        let how_generated = if self.corpus_input > 0 {
+            "loaded from corpus"
+        } else if self.rng_input > 0 {
+            "generated during unknown phase"
+        } else {
+            "unknown"
+        };
+
+        let metadata = json!({
+            "traceback": null
+        });
+
+        let output = json!({
+            "type": "test_case",
+            "run_start": self.json_time.as_secs(),
+            "property": property,
+            "status": status,
+            "status_reason": status_reason,
+            "representation": self.representation,
+            "arguments": self.arguments,
+            "how_generated": how_generated,
+            "features": self.features,
+            "metadata": metadata,
+            "coverage": self.coverage
+        });
+        let output_string = output.to_string();
+        let filename = "tyche_test.jsonl";
+        let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(filename)?;
+        
+        let mut buffered_writer = std::io::BufWriter::new(file);
+        writeln!(buffered_writer, "{}", output_string);
+        let _ = buffered_writer.flush();
+        Ok(())
+
+    }
+}
+
+
+impl Drop for Outcome<'_> {
+    fn drop(&mut self) {
+        eprintln!("{}", self.to_string());
+    }
+}
+
+fn progress() {
+    if cfg!(miri) {
+        use std::io::{stderr, Write};
+
+        // miri doesn't capture explicit writes to stderr
+        #[allow(clippy::explicit_write)]
+        let _ = write!(stderr(), ".");
+    }
+}


### PR DESCRIPTION
This pull request aims to provide support for the tyche analysis tool, to resolve #254. When BOLERO_TYCHE=true cargo test is run, this should create a new file, tyche_test.jsonl, that can be fed into the tyche vscode extension, for example. I'm working with @hgoldstein95 on this

Summary of changes made

-Modified run_with_value to return the representation, even when there is no error. This was because test.generate_value doesn't seem to be callable within the run_tests function. run_with_scope was also modified for the sake of symmetry, to return a placeholder representation
-Modified the outcome branch to have additional fields for representation, features, coverage, and some other fields necessary for tyche. Also added an output_json function that outputs json to the file.
-Modified run_tests to set the representation and features, then output json if the tyche environmental variable is set
-Added a static variable that allows users to use the function event_with_payload in order to set features. This is meant to be like how Hypothesis does events. I used a static global variable because I couldn't figure out how to make an internal variable accessible to someone writing within the function passed into the for_each method
-Made item_path public in lib/bolero-engine/src/target_location.rs so I could use it to set the property name. Let me know if this has any negative effects, and I'll try to figure out a different approach
-Added dependencies on serde_json and lazy_static. Again, let me know if you want the serialization done without using serde_json