### PR TITLE
chore: pin backtrace version to 0.3.74

### DIFF
--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -25,7 +25,7 @@ rand = { version = "0.9", optional = true }
 rand_xoshiro = { version = "0.7", optional = true }
 
 [target.'cfg(not(kani))'.dependencies]
-backtrace = { version = "0.3", default-features = false, features = ["std"] }
+backtrace = { version = "=0.3.74", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 bolero-generator = { version = "0.13", path = "../bolero-generator", features = ["std"] }


### PR DESCRIPTION
### Problem Statement

A dependency of `bolero-engine` backtrace went through a release which bumps its MSRV to 1.82.0: https://crates.io/crates/backtrace/versions. However, `bolero`'s and `S2N-QUIC`'s MSRVs is older than 1.82.0. Hence, the S2N-QUIC's CI is broken because of that: https://github.com/aws/s2n-quic/actions/runs/14874374562.

Hence, we should pin the version of `backtrace` to 0.3.74, which supports our MSRV.

### Testing

The CI of both Bolero should pass, and S2N-QUIC should have a transitive dependency on `backtrace v0.3.74`.
Kani support for 1.66.0 is disabled, and it is documented in https://github.com/camshaft/bolero/issues/274.