### PR TITLE
refactor(bolero-engine): use standard Backtrace instead of backtrace-rs

### DIFF
--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -24,9 +24,6 @@ pretty-hex = { version = "0.4", default-features = false }
 rand = { version = "0.9", optional = true }
 rand_xoshiro = { version = "0.7", optional = true }
 
-[target.'cfg(not(kani))'.dependencies]
-backtrace = { version = "0.3", default-features = false, features = ["std"] }
-
 [dev-dependencies]
 bolero-generator = { version = "0.13", path = "../bolero-generator", features = ["std"] }
 rand = "0.9"


### PR DESCRIPTION
### Problem Statement:

Discussed offline with @camshaft, we should use standard backtrace for `bolero-engine`, so that we can remove our dependency on `backtrace-rs`: https://github.com/camshaft/bolero/pull/282#issuecomment-2860040487.

This PR resolves https://github.com/camshaft/bolero/pull/282.

### Call-outs:

Please review if I fully clean up the customized backtrace structs and its impls.

### Testings:

Use bolero CI to test it.