### PR TITLE
chore: release v0.13.3

### DIFF
--- a/bin/cargo-bolero/Cargo.toml
+++ b/bin/cargo-bolero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bolero"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "cargo command for running bolero fuzz tests"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero-afl/Cargo.toml
+++ b/lib/bolero-afl/Cargo.toml
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine", optional = true }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine", optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -18,14 +18,14 @@ rng = ["rand", "rand_xoshiro", "bolero-generator/alloc"]
 
 [dependencies]
 anyhow = "1"
-bolero-generator = { version = "0.13", path = "../bolero-generator", default-features = false }
+bolero-generator = { version = "0.13.3", path = "../bolero-generator", default-features = false }
 lazy_static = "1"
 pretty-hex = { version = "0.4", default-features = false }
 rand = { version = "0.9", optional = true }
 rand_xoshiro = { version = "0.7", optional = true }
 
 [dev-dependencies]
-bolero-generator = { version = "0.13", path = "../bolero-generator", features = ["std"] }
+bolero-generator = { version = "0.13.3", path = "../bolero-generator", features = ["std"] }
 rand = "0.9"
 rand_xoshiro = "0.7"
 

--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-engine"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "fuzz and property testing framework"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero-generator-derive/Cargo.toml
+++ b/lib/bolero-generator-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-generator-derive"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "value generator for testing and fuzzing"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero-generator/Cargo.toml
+++ b/lib/bolero-generator/Cargo.toml
@@ -19,7 +19,7 @@ alloc = []
 
 [dependencies]
 arbitrary = { version = "1.0", optional = true }
-bolero-generator-derive = { version = "0.13", path = "../bolero-generator-derive" }
+bolero-generator-derive = { version = "0.13.3", path = "../bolero-generator-derive" }
 either = { version = "1.5", default-features = false, optional = true }
 getrandom = { version = "0.3", optional = true }
 rand_core = { version = "0.9", default-features = false }

--- a/lib/bolero-generator/Cargo.toml
+++ b/lib/bolero-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero-generator"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "value generator for testing and fuzzing"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero-honggfuzz/Cargo.toml
+++ b/lib/bolero-honggfuzz/Cargo.toml
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine", optional = true }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine", optional = true }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-kani/Cargo.toml
+++ b/lib/bolero-kani/Cargo.toml
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine", optional = true }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine", optional = true }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-libfuzzer/Cargo.toml
+++ b/lib/bolero-libfuzzer/Cargo.toml
@@ -16,7 +16,7 @@ bin = []
 lib = ["bolero-engine"]
 
 [dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine", features = ["cache"], optional = true }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine", features = ["cache"], optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolero"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "fuzz and property testing front-end"
 homepage = "https://github.com/camshaft/bolero"

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -18,8 +18,8 @@ alloc = ["bolero-generator/alloc"]
 arbitrary = ["bolero-generator/arbitrary"]
 
 [dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine" }
-bolero-generator = { version = "0.13", path = "../bolero-generator", default-features = false }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine" }
+bolero-generator = { version = "0.13.3", path = "../bolero-generator", default-features = false }
 cfg-if = "1"
 
 [target.'cfg(fuzzing_afl)'.dependencies]
@@ -32,14 +32,14 @@ bolero-libfuzzer = { version = "0.13", path = "../bolero-libfuzzer" }
 bolero-honggfuzz = { version = "0.13", path = "../bolero-honggfuzz" }
 
 [target.'cfg(fuzzing_random)'.dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine", features = ["cache", "rng"] }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine", features = ["cache", "rng"] }
 rand = { version = "0.9" }
 
 [target.'cfg(kani)'.dependencies]
 bolero-kani = { version = "0.13", path = "../bolero-kani" }
 
 [target.'cfg(not(any(fuzzing, kani)))'.dependencies]
-bolero-engine = { version = "0.13", path = "../bolero-engine", features = ["cache", "rng"] }
+bolero-engine = { version = "0.13.3", path = "../bolero-engine", features = ["cache", "rng"] }
 rand = { version = "0.9" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Description of Change

Patch release for Bolero. Version bumps to v0.13.3.

### Call-outs:

I followed the previous release PR: https://github.com/camshaft/bolero/pull/281.
Please check if those are the only crates that needs to be released.