### PR TITLE
ci: remove kani from MSRV test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
         profile: minimal
 
     - name: Install kani
+      if: matrix.rust != '1.66.0'
       run: |
         cargo install --locked kani-verifier
         cargo kani setup


### PR DESCRIPTION
Resolve https://github.com/camshaft/bolero/issues/274.

Remove `kani` when the CI is testing with MSRV.