### PR TITLE
feat: enable listing with cargo-nextest and a timeout

### DIFF
--- a/bin/cargo-bolero/src/build_clusterfuzz.rs
+++ b/bin/cargo-bolero/src/build_clusterfuzz.rs
@@ -1,4 +1,4 @@
-use crate::{list::List, project::Project};
+use crate::list::List;
 use anyhow::{Context, Result};
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 pub struct BuildClusterfuzz {
     #[structopt(flatten)]
-    project: Project,
+    list: List,
 }
 
 impl BuildClusterfuzz {
@@ -34,9 +34,7 @@ impl BuildClusterfuzz {
         );
 
         // Figure out the list of fuzz targets, grouped by which test executable they use
-        let targets = List::new(self.project.clone())
-            .list()
-            .context("listing fuzz targets")?;
+        let targets = self.list.list().context("listing fuzz targets")?;
         let mut targets_per_exe = HashMap::new();
         for t in targets {
             targets_per_exe
@@ -54,7 +52,7 @@ impl BuildClusterfuzz {
             let dir = PathBuf::from(format!("{}-{:x}", list_bin, hash));
 
             let fuzz_exe =
-                crate::libfuzzer::build(self.project.clone(), tests[0].test_name.clone())
+                crate::libfuzzer::build(self.list.project().clone(), tests[0].test_name.clone())
                     .context("building to-be-fuzzed executable")?;
             // .cargo extension is not an ALLOWED_FUZZ_TARGET_EXTENSIONS for clusterfuzz, so it doesn’t get picked up as a fuzzer
             let fuzz_bin = format!("{}.cargo", fuzz_exe.file_name().unwrap().to_string_lossy());

--- a/bin/cargo-bolero/src/list.rs
+++ b/bin/cargo-bolero/src/list.rs
@@ -11,22 +11,16 @@ pub struct List {
 }
 
 impl List {
-    pub fn new(project: Project) -> Self {
-        Self { project }
+    pub fn project(&self) -> &Project {
+        &self.project
     }
 
     pub fn list(&self) -> Result<Vec<TestTarget>> {
-        let mut build_command = self.cmd("test", &[], None)?;
-        build_command.arg("--no-run");
+        let build_command = self.cmd("test", false, &["--no-run"], &[], None)?;
         exec(build_command)?;
 
-        let output = self
-            .cmd("test", &[], None)?
-            .arg("--no-fail-fast")
-            .arg("--")
-            .arg("--nocapture")
-            .env("CARGO_BOLERO_SELECT", "all")
-            .output()?;
+        let mut cmd = self.cmd("test", true, &["--no-fail-fast"], &[], None)?;
+        let output = cmd.env("CARGO_BOLERO_SELECT", "all").output()?;
         // ignore the status in case any tests failed
 
         TestTarget::all_from_stdout(&output.stdout)

--- a/bin/cargo-bolero/src/selection.rs
+++ b/bin/cargo-bolero/src/selection.rs
@@ -18,7 +18,7 @@ impl Selection {
     }
 
     pub fn test_target(&self, flags: &[&str], fuzzer: &str) -> Result<TestTarget> {
-        let mut build_command = self.cmd("test", flags, Some(fuzzer))?;
+        let mut build_command = self.cmd("test", false, &[], flags, Some(fuzzer))?;
         build_command
             .arg(&self.test)
             .arg("--no-run")
@@ -26,7 +26,7 @@ impl Selection {
             .arg("--exact");
         exec(build_command)?;
 
-        let mut output_command = self.cmd("test", flags, Some(fuzzer))?;
+        let mut output_command = self.cmd("test", false, &[], flags, Some(fuzzer))?;
         output_command
             .arg(&self.test)
             .arg("--")


### PR DESCRIPTION
Builds on top of https://github.com/camshaft/bolero/pull/289, review only the second commit to see the changes introduced here.

This allows using nextest with a specific nextest profile, instead of cargo test. In particular, with this nextest configuration:
```toml
[profile.list-fuzzers]
slow-timeout = { period = "500ms", terminate-after = 1 }
```

I'm getting the following improvements on listing fuzzers for https://github.com/agglayer/agglayer.
Before:
```
cargo  57.07s user 10.98s system 92% cpu 1:13.75 total
```
After:
```
cargo  8.38s user 3.77s system 47% cpu 25.509 total
```

Which is a ~3x speed improvement, without any fuzzer being missed (because fuzzers naturally reply to `CARGO_BOLERO_SELECT` in less than 500ms) 🎉 

I'm thinking this could be very helpful for large repos, at least until something like https://github.com/camshaft/bolero/issues/196 could get implemented.

WDYT?