### PR TITLE
Fix reduce command

### DIFF
--- a/examples/reduce/Cargo.toml
+++ b/examples/reduce/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reduce"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [workspace]
 members = ["."]

--- a/examples/reduce/Cargo.toml
+++ b/examples/reduce/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "reduce"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+members = ["."]
+
+[dependencies]
+
+[dev-dependencies]
+bolero = { path = "../../lib/bolero" }
+
+
+[profile.fuzz]
+inherits = "dev"
+opt-level = 3
+incremental = false
+codegen-units = 1
+
+

--- a/examples/reduce/src/lib.rs
+++ b/examples/reduce/src/lib.rs
@@ -1,0 +1,22 @@
+pub fn branches(x: u64) -> u64 {
+    if x % 3 == 0 {
+        0
+    } else if x % 5 == 0 {
+        1
+    } else if x % 7 == 0 {
+        2
+    } else {
+        x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_branches() {
+        bolero::check!().with_type::<u64>().cloned().for_each(|x: u64| { branches(x); });
+    }
+}
+

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -5,12 +5,14 @@ mod cargo_bolero;
 mod engines;
 mod env;
 mod examples;
+mod reduce;
 
 fn main() -> Result {
     bolero::test()?;
     cargo_bolero::test()?;
     examples::test()?;
     engines::test()?;
+    reduce::test()?;
 
     Ok(())
 }

--- a/tests/src/reduce.rs
+++ b/tests/src/reduce.rs
@@ -5,7 +5,10 @@ use xshell::{cmd, Shell};
 pub fn test() -> Result {
     let is_nightly = env::rustc_build().map_or(false, |b| b == "nightly");
 
-    Test { rustc_bootstrap: !is_nightly }.run()?;
+    Test {
+        rustc_bootstrap: !is_nightly,
+    }
+    .run()?;
 
     Ok(())
 }

--- a/tests/src/reduce.rs
+++ b/tests/src/reduce.rs
@@ -1,0 +1,84 @@
+use crate::{env, Result};
+use std::{fs, path::PathBuf};
+use xshell::{cmd, Shell};
+
+pub fn test() -> Result {
+    let rust_version = env::rustc();
+
+    let use_stable = rust_version.map_or(false, |v| v.major > 1 && v.minor <= 65);
+
+    Test { use_stable }.run()?;
+
+    Ok(())
+}
+
+struct Test {
+    use_stable: bool,
+}
+
+impl Test {
+    fn run(&self) -> Result {
+        let sh = Shell::new()?;
+        sh.change_dir(env::examples());
+        let _dir = sh.push_dir("reduce");
+
+        // make sure this is up-to-date
+        let _ = sh.remove_path("Cargo.lock");
+
+        env::configure_toolchain(&sh);
+
+        let cargo_bolero = env::bins().to_string() + "/target/debug/cargo-bolero";
+
+        let mut args = Vec::new();
+        if self.use_stable {
+            args.push("--rustc-bootstrap".to_string());
+        }
+
+        let args = &args;
+
+        let test_name = "tests::test_branches";
+
+        cmd!(sh, "{cargo_bolero} test {test_name} --runs 10000 {args...}").run()?;
+
+        // read the generated corpus
+        let corpus_dir =
+            env::examples().to_string() + "/reduce/src/__fuzz__/tests__branches/corpus";
+        let inputs = self.read_corpus(&corpus_dir).unwrap();
+        assert!(!inputs.is_empty());
+
+        let len_before_reduce = inputs.len();
+
+        // create multiple copies of the first input to simulate redundant
+        // inputs
+        const N: usize = 5;
+        let input_name = inputs[0].file_name().unwrap().to_str().unwrap();
+        for i in 0..N {
+            let _ = fs::copy(
+                inputs[0].as_path(),
+                format!("{corpus_dir}/{input_name}_{i}"),
+            );
+        }
+
+        // ensure the copies were created
+        let inputs = self.read_corpus(&corpus_dir).unwrap();
+        assert_eq!(inputs.len(), len_before_reduce + N);
+
+        // run the reduce command
+        cmd!(sh, "{cargo_bolero} reduce {test_name} {args...}").run()?;
+
+        // ensure the redundant inputs were removed
+        let inputs = self.read_corpus(&corpus_dir).unwrap();
+
+        assert_eq!(inputs.len(), len_before_reduce);
+
+        Ok(())
+    }
+
+    fn read_corpus(&self, corpus_dir: &str) -> Result<Vec<PathBuf>> {
+        let inputs: Vec<_> = fs::read_dir(corpus_dir)?
+            .filter_map(|entry| Some(entry.ok()?.path()))
+            .collect();
+
+        Ok(inputs)
+    }
+}


### PR DESCRIPTION
The reduce command currently doesn't remove redundant inputs in the corpus (see #247). This PR fixes it.

Keeping this as a draft till I add a test.