### PR TITLE
fix: branch result handling and strengthen tests

### DIFF
--- a/examples/reduce/src/lib.rs
+++ b/examples/reduce/src/lib.rs
@@ -16,7 +16,20 @@ mod tests {
 
     #[test]
     fn test_branches() {
-        bolero::check!().with_type::<u64>().cloned().for_each(|x: u64| { branches(x); });
+        bolero::check!()
+            .with_type::<u64>()
+            .cloned()
+            .for_each(|x: u64| {
+                let result = branches(x);
+                if x % 3 == 0 {
+                    assert_eq!(result, 0);
+                } else if x % 5 == 0 {
+                    assert_eq!(result, 1);
+                } else if x % 7 == 0 {
+                    assert_eq!(result, 2);
+                } else {
+                    assert_eq!(result, x);
+                }
+            });
     }
 }
-


### PR DESCRIPTION
updated the logic inside `for_each` to actually store the result of `branches(x)` in `result`.
added `assert_eq!` checks to make sure the function behaves correctly for all random inputs.

p.s. previously, the function was called but its output wasn't verified, so tests could pass even if the logic was wrong.
now the behavior is properly validated.
