### PR TITLE
build(deps): update proc-macro-crate to version 3

### DIFF
--- a/lib/bolero-generator-derive/Cargo.toml
+++ b/lib/bolero-generator-derive/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../bolero-generator/README.md"
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "2"
+proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"
 # The `full` feature is required to correctly parse attributes


### PR DESCRIPTION
Bumps the minimum Rust version and removes the pin of `toml_edit`:
https://github.com/bkchr/proc-macro-crate/commit/71c28e2a2592a9dc85afbdb4bc346a0296999eed

https://github.com/bkchr/proc-macro-crate/releases/tag/v3.0.0
https://github.com/bkchr/proc-macro-crate/releases/tag/v3.1.0
https://github.com/bkchr/proc-macro-crate/releases/tag/v3.2.0
https://github.com/bkchr/proc-macro-crate/releases/tag/v3.3.0
https://github.com/bkchr/proc-macro-crate/releases/tag/v3.4.0
