### PR TITLE
build(deps): update rand to version 0.10

### DIFF
--- a/lib/bolero-engine/Cargo.toml
+++ b/lib/bolero-engine/Cargo.toml
@@ -21,13 +21,13 @@ anyhow = "1"
 bolero-generator = { version = "0.13.5", path = "../bolero-generator", default-features = false }
 lazy_static = "1"
 pretty-hex = { version = "0.4", default-features = false }
-rand = { version = "0.9", optional = true }
-rand_xoshiro = { version = "0.7", optional = true }
+rand = { version = "0.10", optional = true }
+rand_xoshiro = { version = "0.8", optional = true }
 
 [dev-dependencies]
 bolero-generator = { version = "0.13.5", path = "../bolero-generator", features = ["std"] }
-rand = "0.9"
-rand_xoshiro = "0.7"
+rand = "0.10"
+rand_xoshiro = "0.8"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-generator/Cargo.toml
+++ b/lib/bolero-generator/Cargo.toml
@@ -22,12 +22,12 @@ arbitrary = { version = "1.0", optional = true }
 bolero-generator-derive = { version = "0.13.4", path = "../bolero-generator-derive" }
 either = { version = "1.5", default-features = false, optional = true }
 getrandom = { version = "0.3", optional = true }
-rand_core = { version = "0.9", default-features = false }
-rand_xoshiro = { version = "0.7", optional = true }
+rand_core = { version = "0.10", default-features = false }
+rand_xoshiro = { version = "0.8", optional = true }
 
 [dev-dependencies]
 insta = "1"
-rand = "0.9"
+rand = "0.10"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero-generator/src/driver.rs
+++ b/lib/bolero-generator/src/driver.rs
@@ -3,7 +3,7 @@ use crate::{
     TypeGenerator, ValueGenerator,
 };
 use core::ops::Bound;
-use rand_core::TryRngCore;
+use rand_core::TryRng;
 
 #[macro_use]
 mod macros;

--- a/lib/bolero-generator/src/driver/exhaustive.rs
+++ b/lib/bolero-generator/src/driver/exhaustive.rs
@@ -4,6 +4,7 @@ use crate::{
     uniform::{self, Uniform},
 };
 use alloc::vec::Vec;
+use core::convert::Infallible;
 use core::ops::{Bound, ControlFlow};
 
 #[derive(Clone, Debug)]
@@ -318,25 +319,28 @@ impl_driver!(&mut Driver);
 
 struct Rng<'a>(&'a mut State);
 
-impl rand_core::RngCore for Rng<'_> {
-    fn next_u32(&mut self) -> u32 {
-        self.0.select(u32::MAX as _) as _
+impl rand_core::TryRng for Rng<'_> {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.0.select(u32::MAX as _) as _)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        self.0.select(u64::MAX)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.0.select(u64::MAX))
     }
 
-    fn fill_bytes(&mut self, mut dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, mut dest: &mut [u8]) -> Result<(), Self::Error> {
         while dest.len() >= 8 {
             let (chunk, rest) = dest.split_at_mut(8);
             dest = rest;
-            let value = self.next_u64();
+            let value = self.try_next_u64()?;
             chunk.copy_from_slice(&value.to_be_bytes());
         }
 
         let value = self.0.select((1 << dest.len()) * 8);
         dest.copy_from_slice(&value.to_be_bytes()[..dest.len()]);
+        Ok(())
     }
 }
 

--- a/lib/bolero-generator/src/driver/rng.rs
+++ b/lib/bolero-generator/src/driver/rng.rs
@@ -6,7 +6,7 @@ pub(crate) use buffer_alloc::Buffer;
 pub(crate) use buffer_no_alloc::Buffer;
 
 #[derive(Debug)]
-pub struct Rng<R: TryRngCore> {
+pub struct Rng<R: TryRng> {
     rng: R,
     depth: usize,
     max_depth: usize,
@@ -16,7 +16,7 @@ pub struct Rng<R: TryRngCore> {
     buffer: Buffer,
 }
 
-impl<R: TryRngCore> Rng<R> {
+impl<R: TryRng> Rng<R> {
     pub fn new(rng: R, options: &Options) -> Self {
         Self {
             rng,
@@ -54,7 +54,7 @@ impl<R: TryRngCore> Rng<R> {
     }
 }
 
-impl<R: TryRngCore> AsRef<R> for Rng<R> {
+impl<R: TryRng> AsRef<R> for Rng<R> {
     #[inline]
     fn as_ref(&self) -> &R {
         &self.rng
@@ -62,8 +62,8 @@ impl<R: TryRngCore> AsRef<R> for Rng<R> {
 }
 
 #[inline]
-fn fill_bytes<R: TryRngCore>(rng: &mut R, bytes: &mut [u8]) -> Option<()> {
-    if TryRngCore::try_fill_bytes(rng, bytes).is_err() {
+fn fill_bytes<R: TryRng>(rng: &mut R, bytes: &mut [u8]) -> Option<()> {
+    if TryRng::try_fill_bytes(rng, bytes).is_err() {
         // if the rng fails to fill the remaining bytes, then we just start returning 0s
         for byte in bytes.iter_mut() {
             *byte = 0;
@@ -87,7 +87,7 @@ macro_rules! impl_sample {
     };
 }
 
-impl<R: TryRngCore> FillBytes for Rng<R> {
+impl<R: TryRng> FillBytes for Rng<R> {
     // prefer sampling the larger values since it's faster to pull from the RNG
     const SHOULD_SHRINK: bool = false;
 
@@ -124,7 +124,7 @@ impl<R: TryRngCore> FillBytes for Rng<R> {
     impl_sample!(sample_isize, isize, try_next_u64);
 }
 
-impl<R: TryRngCore> Driver for Rng<R> {
+impl<R: TryRng> Driver for Rng<R> {
     gen_from_bytes!();
 
     #[inline]
@@ -178,7 +178,7 @@ mod buffer_alloc {
         pub const MAX_CAPACITY: usize = isize::MAX as _;
 
         #[inline]
-        pub fn fill<R: TryRngCore>(&mut self, len: usize, rng: &mut R) -> Option<()> {
+        pub fn fill<R: TryRng>(&mut self, len: usize, rng: &mut R) -> Option<()> {
             let data = &mut self.bytes;
 
             let initial_len = data.len();
@@ -231,7 +231,7 @@ mod buffer_no_alloc {
         pub const MAX_CAPACITY: usize = 256;
 
         #[inline]
-        pub fn fill<R: TryRngCore>(&mut self, len: usize, rng: &mut R) -> Option<()> {
+        pub fn fill<R: TryRng>(&mut self, len: usize, rng: &mut R) -> Option<()> {
             if cfg!(test) {
                 assert!(len <= Self::MAX_CAPACITY);
             }

--- a/lib/bolero/Cargo.toml
+++ b/lib/bolero/Cargo.toml
@@ -33,17 +33,17 @@ bolero-honggfuzz = { version = "0.13", path = "../bolero-honggfuzz" }
 
 [target.'cfg(fuzzing_random)'.dependencies]
 bolero-engine = { version = "0.13.4", path = "../bolero-engine", features = ["cache", "rng"] }
-rand = { version = "0.9" }
+rand = "0.10"
 
 [target.'cfg(kani)'.dependencies]
 bolero-kani = { version = "0.13", path = "../bolero-kani" }
 
 [target.'cfg(not(any(fuzzing, kani)))'.dependencies]
 bolero-engine = { version = "0.13.4", path = "../bolero-engine", features = ["cache", "rng"] }
-rand = { version = "0.9" }
+rand = "0.10"
 
 [dev-dependencies]
-rand = "0.9"
+rand = "0.10"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/lib/bolero/src/test/input.rs
+++ b/lib/bolero/src/test/input.rs
@@ -2,7 +2,8 @@
 
 use bolero_engine::{rng::Recommended as Rng, Seed};
 use bolero_generator::{driver, TypeGenerator};
-use rand::SeedableRng;
+use core::convert::Infallible;
+use rand::{Rng as _, SeedableRng};
 use std::{io::Read, path::PathBuf};
 
 pub use bolero_engine::input::*;
@@ -82,22 +83,25 @@ pub struct BufferedRng<'a> {
     buffer: &'a mut Vec<u8>,
 }
 
-impl rand::RngCore for BufferedRng<'_> {
-    fn next_u32(&mut self) -> u32 {
+impl rand::TryRng for BufferedRng<'_> {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut data = [0; 4];
-        self.fill_bytes(&mut data);
-        u32::from_le_bytes(data)
+        self.try_fill_bytes(&mut data)?;
+        Ok(u32::from_le_bytes(data))
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let mut data = [0; 8];
-        self.fill_bytes(&mut data);
-        u64::from_le_bytes(data)
+        self.try_fill_bytes(&mut data)?;
+        Ok(u64::from_le_bytes(data))
     }
 
-    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), Self::Error> {
         self.rng.fill_bytes(bytes);
         self.buffer.extend_from_slice(bytes);
+        Ok(())
     }
 }
 
@@ -124,26 +128,29 @@ pub struct ReplayRng<'a> {
     buffer: &'a [u8],
 }
 
-impl rand::RngCore for ReplayRng<'_> {
-    fn next_u32(&mut self) -> u32 {
+impl rand::TryRng for ReplayRng<'_> {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut data = [0; 4];
-        self.fill_bytes(&mut data);
-        u32::from_le_bytes(data)
+        self.try_fill_bytes(&mut data)?;
+        Ok(u32::from_le_bytes(data))
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let mut data = [0; 8];
-        self.fill_bytes(&mut data);
-        u64::from_le_bytes(data)
+        self.try_fill_bytes(&mut data)?;
+        Ok(u64::from_le_bytes(data))
     }
 
-    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), Self::Error> {
         let len = self.buffer.len().min(bytes.len());
         let (copy_from, remaining) = self.buffer.split_at(len);
         let (copy_to, fill_to) = bytes.split_at_mut(len);
         copy_to.copy_from_slice(copy_from);
         fill_to.fill(0);
         self.buffer = remaining;
+        Ok(())
     }
 }
 

--- a/lib/bolero/src/test/mod.rs
+++ b/lib/bolero/src/test/mod.rs
@@ -109,11 +109,14 @@ impl TestEngine {
     }
 
     fn rng_tests(&self) -> impl Iterator<Item = input::RngTest> {
-        use rand::{rngs::StdRng, RngCore, SeedableRng};
+        use rand::{
+            rngs::{StdRng, SysRng},
+            Rng as _, SeedableRng as _,
+        };
 
         let iterations = self.rng_cfg.iterations_or_default();
         // use StdRng for high entropy seeds
-        let mut seed_rng = StdRng::from_os_rng();
+        let mut seed_rng = StdRng::try_from_rng(&mut SysRng).unwrap();
 
         (0..iterations).map(move |_| {
             let mut seed = [0; size_of::<Seed>()];


### PR DESCRIPTION
https://github.com/rust-random/rand/releases/tag/0.10.0

Notable changes:

- Renamed `*RngCore` in `rand_core` to `*Rng`
- Renamed `*Rng` in `rand` to `*RngExt`
- Moved `rand_core::OsRng` to `rand` and renamed to `SysRng`
- Dropped `from_os_rng` constructor.
