### PR TITLE
feat: add with_verbose() API and BOLERO_VERBOSE env var for per-itera…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,29 @@ available the requirement can be relaxed by executing `cargo install cargo-boler
 ```bash
 $ sudo apt install binutils-dev libunwind-dev
 ```
+
+### Verbose Output
+
+Set `BOLERO_VERBOSE` to enable additional output during test runs:
+
+```console
+$ BOLERO_VERBOSE=seed cargo test
+running tests::model_test with seed=257980385844766853829307593552934182957
+running tests::model_test with seed=89281095907698073451614483067208970550
+```
+
+Accepted values (comma-separated):
+- `seed` — print the seed before each RNG-based iteration
+- `1` or `all` — enable all verbose output
+
+This can also be enabled per-test in code:
+
+```rust
+use bolero::{check, Verbose};
+
+check!()
+    .with_verbose(Verbose::Seed)
+    .for_each(|input| {
+        // ...
+    });
+```

--- a/lib/bolero/src/lib.rs
+++ b/lib/bolero/src/lib.rs
@@ -40,6 +40,13 @@ pub use bolero_engine::{Driver, Engine, Test};
 #[cfg(test)]
 mod tests;
 
+/// Controls what additional verbose output is printed during a test run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verbose {
+    /// Print the seed for each RNG-based test input
+    Seed,
+}
+
 /// Execute tests for a given target
 ///
 /// This should be executed in a separate test target, for example
@@ -392,6 +399,12 @@ cfg_if::cfg_if! {
                 self.driver_options.set_max_len(max_len);
                 self
             }
+
+            /// Configure additional verbose output during the test run
+            pub fn with_verbose(self, output: Verbose) -> Self {
+                let _ = output;
+                self
+            }
         }
     } else {
         impl<G, InputOwnership> TestTarget<G, crate::test::TestEngine, InputOwnership> {
@@ -411,6 +424,12 @@ cfg_if::cfg_if! {
             pub fn with_max_len(mut self, max_len: usize) -> Self {
                 self.driver_options.set_max_len(max_len);
                 self.engine.with_max_len(max_len);
+                self
+            }
+
+            /// Configure additional verbose output during the test run
+            pub fn with_verbose(mut self, output: Verbose) -> Self {
+                self.engine.with_verbose(output);
                 self
             }
         }

--- a/lib/bolero/src/test/mod.rs
+++ b/lib/bolero/src/test/mod.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(fuzzing_random, allow(dead_code))]
 
+use crate::Verbose;
 use bolero_engine::{
     driver::{self, exhaustive, object::Object},
     rng, Engine, Failure, Seed, TargetLocation, Test,
@@ -20,6 +21,7 @@ mod report;
 pub struct TestEngine {
     location: TargetLocation,
     rng_cfg: rng::Options,
+    outputs: Vec<Verbose>,
 }
 
 struct NamedTest {
@@ -53,6 +55,7 @@ impl TestEngine {
         Self {
             location,
             rng_cfg: Default::default(),
+            outputs: parse_verbose_env(),
         }
     }
 
@@ -68,6 +71,13 @@ impl TestEngine {
 
     pub fn with_max_len(&mut self, max_len: usize) -> &mut Self {
         self.rng_cfg.max_len = self.rng_cfg.max_len.or(Some(max_len));
+        self
+    }
+
+    pub fn with_verbose(&mut self, output: Verbose) -> &mut Self {
+        if !self.outputs.contains(&output) {
+            self.outputs.push(output);
+        }
         self
     }
 
@@ -348,6 +358,13 @@ impl TestEngine {
             Some(self.rng_cfg.test_time_or_default()).filter(|v| *v < Duration::MAX)
         };
 
+        let has_verbose = |v: Verbose| self.outputs.contains(&v);
+        let test_name = self
+            .location
+            .test_name
+            .clone()
+            .unwrap_or_else(|| self.location.item_path());
+
         let mut report = report::Report::default();
         if cfg!(fuzzing_random) {
             report.spawn_timer();
@@ -366,6 +383,12 @@ impl TestEngine {
                         default: self.rng_cfg.test_time.is_none(),
                     });
                     break;
+                }
+            }
+
+            if has_verbose(Verbose::Seed) {
+                if let input::Test::Rng(rng) = &input.data {
+                    eprintln!("running {test_name} with seed={}", rng.seed);
                 }
             }
 
@@ -462,4 +485,20 @@ impl bolero_engine::ScopedEngine for TestEngine {
         self.run_with_scope(test, options);
         bolero_engine::panic::forward_panic(true);
     }
+}
+
+fn parse_verbose_env() -> Vec<Verbose> {
+    let Ok(val) = std::env::var("BOLERO_VERBOSE") else {
+        return Vec::new();
+    };
+
+    let mut outputs = Vec::new();
+    for item in val.split(',') {
+        match item.trim().to_lowercase().as_str() {
+            "1" | "all" => return vec![Verbose::Seed],
+            "seed" => outputs.push(Verbose::Seed),
+            _ => {}
+        }
+    }
+    outputs
 }


### PR DESCRIPTION
…tion seed output

Adds a Verbose enum with a Seed variant that prints the RNG seed before each iteration, useful for reproducing timeout/kill failures where the failure banner never fires.

Can be enabled per-test with .with_verbose(Verbose::Seed) or globally via BOLERO_VERBOSE=seed (also accepts '1' or 'all' for all variants, comma-separated).